### PR TITLE
fix: use BatchLogRecordProcessor

### DIFF
--- a/Sources/AwsOpenTelemetryCore/AwsOpenTelemetryRumBuilder.swift
+++ b/Sources/AwsOpenTelemetryCore/AwsOpenTelemetryRumBuilder.swift
@@ -426,7 +426,7 @@ public class AwsOpenTelemetryRumBuilder {
                                    resource: Resource) -> LoggerProvider {
     // Create initial builder
     let builder = LoggerProviderBuilder()
-      .with(processors: [SimpleLogRecordProcessor(logRecordExporter: logExporter)])
+      .with(processors: [BatchLogRecordProcessor(logRecordExporter: logExporter)])
       .with(resource: resource)
 
     // Apply all customizers in order


### PR DESCRIPTION
We should be doing batch processing

Edit: 

From AWS well architected:

> Batching your write requests rather than creating many short-lived transactions can help improve throughput in high-write volume

https://docs.aws.amazon.com/wellarchitected/2025-02-25/framework/perf_data_evaluate_configuration_options_data_store.html