### PR TITLE
chore: combine code quality jobs

### DIFF
--- a/.github/workflows/CodeQL.yml
+++ b/.github/workflows/CodeQL.yml
@@ -1,5 +1,5 @@
 # AWS OpenTelemetry CodeQL - Code Quality checks
-# Runs SwiftFormat and SwiftLint on changed files
+# Runs SwiftFormat and SwiftLint on entire repository
 # Triggered on: PR creation/updates, manual dispatch
 
 name: CodeQL
@@ -13,49 +13,11 @@ permissions:
   contents: read
 
 jobs:
-  FormattingLint:
+  lint:
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-      - name: Install SwiftFormat
-        run: brew install swiftformat
-      - name: SwiftFormat
-        run: |
-          git fetch origin main
-          swift_files=$(git diff --name-only origin/main...HEAD | grep '\.swift$' || true)
-          if [ -n "$swift_files" ]; then
-            echo "Checking SwiftFormat on changed files:"
-            echo "$swift_files"
-            echo "Running SwiftFormat with detailed output..."
-            swiftformat --lint $swift_files --reporter github-actions-log --verbose
-            if [ $? -ne 0 ]; then
-              echo "SwiftFormat violations found. Run 'swiftformat .' to fix automatically."
-              echo "Files that need formatting:"
-              swiftformat --lint $swift_files --reporter json | jq -r '.[] | select(.violations | length > 0) | .file'
-            fi
-          else
-            echo "No Swift files to check"
-          fi
-
-  SwiftLint:
-    runs-on: macos-15
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-      - name: Install SwiftLint
-        run: brew install swiftlint
-      - name: SwiftLint
-        run: |
-          git fetch origin main
-          swift_files=$(git diff --name-only origin/main...HEAD | grep '\.swift$' || true)
-          if [ -n "$swift_files" ]; then
-            echo "Checking SwiftLint on changed files:"
-            echo "$swift_files"
-            echo "Running SwiftLint..."
-            swiftlint lint --strict $swift_files
-          else
-            echo "No Swift files to check"
-          fi
+      - name: Install tools
+        run: brew install swiftformat swiftlint
+      - name: Run linting
+        run: make lint

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,21 @@ setup-brew:  ## Install required tools (xcbeautify)
 check-coverage:  ## Run tests with coverage and check thresholds
 	./scripts/check-coverage.sh
 
+.PHONY: lint-format
+lint-format:  ## Run SwiftFormat linting
+	find . -name '*.swift' -not -path './.build/*' | xargs swiftformat --lint
+
+.PHONY: lint-swift
+lint-swift:  ## Run SwiftLint
+	find . -name '*.swift' -not -path './.build/*' | xargs swiftlint lint --strict
+
+.PHONY: format
+format:  ## Auto-fix formatting issues with SwiftFormat
+	find . -name '*.swift' -not -path './.build/*' | xargs swiftformat
+
+.PHONY: lint
+lint: lint-format lint-swift  ## Run all linting checks
+
 # Build Commands - Compile code for each platform
 .PHONY: build-ios
 build-ios:  ## Build for iOS


### PR DESCRIPTION
## Summary

The lint job could not handle deleted files well because it was specifically looking for changed files - https://github.com/aws-observability/aws-otel-swift/actions/runs/17319722320/job/49170086765?pr=24

## Implementation

1. I change the lint job to look at all swift files. This is less prone to bugs and fine for us, since the repo is already in a good state
2. I combined the lint jobs into a single workflow to be a little more frugal. 

I also added `make lint` so that developers can check their lint in the same way as the approval workflow. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

