### PR TITLE
chore: Add observed timestamp to log records

### DIFF
--- a/Sources/AwsOpenTelemetryCore/MetricKit/AwsMetricKitCrashProcessor.swift
+++ b/Sources/AwsOpenTelemetryCore/MetricKit/AwsMetricKitCrashProcessor.swift
@@ -17,6 +17,7 @@
         AwsOpenTelemetryLogger.debug("Emitting crash log record with \(attributes.count) attributes")
         logger.logRecordBuilder()
           .setBody(AttributeValue.string("crash"))
+          .setObservedTimestamp(Date())
           .setAttributes(attributes)
           .emit()
       }

--- a/Sources/AwsOpenTelemetryCore/MetricKit/AwsMetricKitHangProcessor.swift
+++ b/Sources/AwsOpenTelemetryCore/MetricKit/AwsMetricKitHangProcessor.swift
@@ -18,6 +18,7 @@
         logger.logRecordBuilder()
           .setBody(AttributeValue.string("hang"))
           .setAttributes(attributes)
+          .setObservedTimestamp(Date())
           .emit()
       }
     }

--- a/Sources/AwsOpenTelemetryCore/Sessions/AwsSessionEventInstrumentation.swift
+++ b/Sources/AwsOpenTelemetryCore/Sessions/AwsSessionEventInstrumentation.swift
@@ -148,6 +148,7 @@ public class AwsSessionEventInstrumentation {
     logger.logRecordBuilder()
       .setBody(AttributeValue.string(AwsSessionConstants.sessionStartEvent))
       .setAttributes(attributes)
+      .setObservedTimestamp(Date())
       .emit()
   }
 
@@ -181,6 +182,7 @@ public class AwsSessionEventInstrumentation {
     logger.logRecordBuilder()
       .setBody(AttributeValue.string(AwsSessionConstants.sessionEndEvent))
       .setAttributes(attributes)
+      .setObservedTimestamp(Date())
       .emit()
   }
 

--- a/Tests/AwsOpenTelemetryCoreTests/MetricKit/AwsMetricKitCrashProcessorTests.swift
+++ b/Tests/AwsOpenTelemetryCoreTests/MetricKit/AwsMetricKitCrashProcessorTests.swift
@@ -43,6 +43,7 @@
       let log = logs[0]
       XCTAssertEqual(log.body?.description, "crash")
       XCTAssertEqual(log.instrumentationScopeInfo.name, "software.amazon.opentelemetry.MXCrashDiagnostic")
+      XCTAssertNotNil(log.observedTimestamp, "Observed timestamp should be set")
       XCTAssertEqual(log.attributes["crash.exception_type"]?.description, "1")
       XCTAssertEqual(log.attributes["crash.exception_code"]?.description, "2")
       XCTAssertEqual(log.attributes["crash.signal"]?.description, "11")
@@ -61,6 +62,24 @@
       XCTAssertEqual(attributes["crash.termination_reason"]?.description, "test termination")
       XCTAssertEqual(attributes["crash.vm_region.info"]?.description, "test vm info")
       XCTAssertEqual(attributes["crash.stacktrace"]?.description, "{\"test\":\"stacktrace\"}")
+    }
+
+    func testObservedTimestampIsSetOnCrashLog() {
+      let beforeTime = Date()
+      let mockCrash = MockMXCrashDiagnostic()
+      AwsMetricKitCrashProcessor.processCrashDiagnostics([mockCrash])
+      let afterTime = Date()
+
+      let logs = logExporter.getExportedLogs()
+      XCTAssertEqual(logs.count, 1)
+
+      let log = logs[0]
+      XCTAssertNotNil(log.observedTimestamp)
+
+      // Verify the observed timestamp is within a reasonable range
+      let observedTime = log.observedTimestamp!
+      XCTAssertGreaterThanOrEqual(observedTime, beforeTime)
+      XCTAssertLessThanOrEqual(observedTime, afterTime)
     }
   }
 


### PR DESCRIPTION
## Summary

`observedTimeUnixNano` is missing from log records, which is causing ingestion failures based on the logs protocol https://github.com/open-telemetry/opentelemetry-proto/blob/v1.5.0/opentelemetry/proto/logs/v1/logs.proto#L159

## Testing

Unit tests