### PR TITLE
chore: Disable payload compression in trace and log exporter

### DIFF
--- a/Sources/AwsOpenTelemetryCore/AwsOpenTelemetryRumBuilder.swift
+++ b/Sources/AwsOpenTelemetryCore/AwsOpenTelemetryRumBuilder.swift
@@ -16,6 +16,7 @@
 import Foundation
 
 import OpenTelemetryApi
+import OpenTelemetryProtocolExporterCommon
 import OpenTelemetryProtocolExporterHttp
 import OpenTelemetrySdk
 import ResourceExtension
@@ -366,7 +367,7 @@ public class AwsOpenTelemetryRumBuilder {
    * @return A configured span exporter
    */
   private func buildSpanExporter(tracesEndpointURL: URL) -> SpanExporter {
-    let traceExporter = OtlpHttpTraceExporter(endpoint: tracesEndpointURL)
+    let traceExporter = OtlpHttpTraceExporter(endpoint: tracesEndpointURL, config: OtlpConfiguration(compression: .none))
     let defaultExporter: SpanExporter = if config.debug ?? false {
       MultiSpanExporter(spanExporters: [
         traceExporter,
@@ -386,7 +387,7 @@ public class AwsOpenTelemetryRumBuilder {
    * @return A configured log record exporter
    */
   private func buildLogsExporter(logsEndpointURL: URL) -> LogRecordExporter {
-    let logsExporter = OtlpHttpLogExporter(endpoint: logsEndpointURL)
+    let logsExporter = OtlpHttpLogExporter(endpoint: logsEndpointURL, config: OtlpConfiguration(compression: .none))
     let defaultExporter: LogRecordExporter = if config.debug ?? false {
       MultiLogRecordExporter(logRecordExporters: [
         logsExporter,


### PR DESCRIPTION
The current RUM OTEL endpoint is not able to handle requests that are gzip compressed. By default, upstream does compression and does not expose it as a configuration option. 

For the time being, aws-swift will disable compression until the endpoint is updated to handle compressed requests. 

This has been tested with a demo app and telemetry was successfully captured in AWS RUM


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

