### PR TITLE
fix: migrate app attributes to resource

### DIFF
--- a/Sources/AwsOpenTelemetryCore/AwsOpenTelemetryRumBuilder.swift
+++ b/Sources/AwsOpenTelemetryCore/AwsOpenTelemetryRumBuilder.swift
@@ -97,14 +97,6 @@ public class AwsOpenTelemetryRumBuilder {
     let sessionConfig = AwsSessionConfig(sessionTimeout: config.sessionTimeout ?? AwsSessionConfig.default.sessionTimeout)
     let sessionManager = AwsSessionManager(configuration: sessionConfig)
     AwsSessionManagerProvider.register(sessionManager: sessionManager)
-
-    // Add applicationAttributes to global attributes
-    if let applicationAttributes = config.applicationAttributes {
-      let globalAttributesManager = GlobalAttributesProvider.getInstance()
-      for (key, value) in applicationAttributes {
-        globalAttributesManager.setAttribute(key: key, value: AttributeValue.string(value))
-      }
-    }
   }
 
   /**

--- a/Sources/AwsOpenTelemetryCore/Utils/AwsResourceBuilder.swift
+++ b/Sources/AwsOpenTelemetryCore/Utils/AwsResourceBuilder.swift
@@ -47,10 +47,15 @@ public class AwsResourceBuilder {
       SemanticConventions.Device.modelName.rawValue: DeviceKitPolyfill.getDeviceName()
     ]
 
-    let resource = DefaultResources().get()
+    var resource = DefaultResources().get()
       .merging(other: Resource(attributes: buildAttributeMap(rumResourceAttributes)))
       .merging(other: Resource(attributes: buildAttributeMap(cloudResourceAttributes)))
       .merging(other: Resource(attributes: buildAttributeMap(deviceResourceAttributes)))
+
+    // Add application attributes to resource
+    if let applicationAttributes = config.applicationAttributes {
+      resource = resource.merging(other: Resource(attributes: buildAttributeMap(applicationAttributes)))
+    }
 
     return resource
   }

--- a/Tests/AwsOpenTelemetryCoreTests/Utils/AwsResourceBuilderTests.swift
+++ b/Tests/AwsOpenTelemetryCoreTests/Utils/AwsResourceBuilderTests.swift
@@ -47,6 +47,16 @@ final class AwsResourceBuilderTests: XCTestCase {
     XCTAssertNotNil(resource.attributes["device.model.name"])
   }
 
+  func testBuildResourceWithApplicationAttributes() {
+    let config = AwsOpenTelemetryConfig(
+      aws: AwsConfig(region: "us-east-1", rumAppMonitorId: "test-id"),
+      applicationAttributes: ["application.version": "1.0.0", "application.name": "TestApp"]
+    )
+    let resource = AwsResourceBuilder.buildResource(config: config)
+    XCTAssertEqual(resource.attributes["application.version"]?.description, "1.0.0")
+    XCTAssertEqual(resource.attributes["application.name"]?.description, "TestApp")
+  }
+
   func testBuildResourceIncludesUpstreamAttributes() {
     let config = AwsOpenTelemetryConfig(aws: AwsConfig(region: "us-east-1", rumAppMonitorId: "test-id"))
     let resource = AwsResourceBuilder.buildResource(config: config)
@@ -91,7 +101,10 @@ final class AwsResourceBuilderTests: XCTestCase {
   func testLogRecordsCreatedWithResource() {
     let logExporter = InMemoryLogExporter()
     let resource = AwsResourceBuilder.buildResource(
-      config: AwsOpenTelemetryConfig(aws: AwsConfig(region: "us-west-2", rumAppMonitorId: "log-test-id"))
+      config: AwsOpenTelemetryConfig(
+        aws: AwsConfig(region: "us-west-2", rumAppMonitorId: "log-test-id"),
+        applicationAttributes: ["application.version": "2.0.0"]
+      )
     )
 
     let loggerProvider = LoggerProviderBuilder()
@@ -108,6 +121,7 @@ final class AwsResourceBuilderTests: XCTestCase {
     let logRecord = exportedLogs[0]
     XCTAssertEqual(logRecord.resource.attributes[AwsAttributes.rumAppMonitorId.rawValue]?.description, "log-test-id")
     XCTAssertEqual(logRecord.resource.attributes["cloud.region"]?.description, "us-west-2")
+    XCTAssertEqual(logRecord.resource.attributes["application.version"]?.description, "2.0.0")
     XCTAssertNotNil(logRecord.resource.attributes["device.model.name"])
   }
 }


### PR DESCRIPTION
## Summary

This is a performance improvement. 

"Application attributes" as they are defined here are bloating the payload size because they are written to global attributes, which are copied per log and span. Instead, they should go in resource attributes.

1. This cuts down payload size by factor of `1/mn`, where `n` is the number of spans/logs and `m` is the number of application attributes. If we do not do this, we we risk dropping data due to exceeding client-side limits. We also increase risk of dropping data during network transfer, not to mention the latency impact. 
2. Application attributes are immutable, so they naturally also belong in the immutable resource attributes object.

On the backend, both resource and regular attributes are easily queryable. So the only difference is how much we care about this payload, which we should care about a lot. 

Last, If a customer wants to restore the previous behavior, they are welcome to configure global attributes via the existing GlobalAttributes API.

## Example

Let's say you have application attributes x, y, and z. With the existing setup, you would redundant data like this. 

```
payload 
 ├── resource attributes (empty)
 ├── spans
 ├────── span with attributes (1,2,3)
 ├────── span with attributes (1,2,3)
 ├────── span with attributes (1,2,3)
 └────── ...
```

However, with this CR, the payload is simplified like this. 

```
payload 
 ├── resource attributes (1,2,3)
 ├── spans
 ├────── span with attributes (empty)
 ├────── span with attributes (empty)
 ├────── span with attributes (empty)
 └────── ...
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

