### PR TITLE
feat: kscrash reporter with recovery context

### DIFF
--- a/Sources/AwsOpenTelemetryCore/Constants/AwsInstrumentationScopes.swift
+++ b/Sources/AwsOpenTelemetryCore/Constants/AwsInstrumentationScopes.swift
@@ -25,4 +25,5 @@ public enum AwsInstrumentationScopes {
   public static let UIKIT_VIEW = "software.amazon.opentelemetry.UIKitView"
   public static let SWIFTUI_VIEW = "software.amazon.opentelemetry.SwiftUIView"
   public static let HANG = "software.amazon.opentelemetry.Hang"
+  public static let KSCRASH = "software.amazon.opentelemetry.kscrash"
 }

--- a/Sources/AwsOpenTelemetryCore/KSCrash/AwsKSCrashInstrumentation.swift
+++ b/Sources/AwsOpenTelemetryCore/KSCrash/AwsKSCrashInstrumentation.swift
@@ -1,0 +1,296 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import Foundation
+import OpenTelemetryApi
+
+#if canImport(KSCrashRecording)
+  import KSCrashRecording
+#elseif canImport(KSCrash)
+  import KSCrash
+#endif
+
+#if canImport(KSCrashFilters)
+  import KSCrashFilters
+#endif
+
+protocol CrashProtocol {
+  static func install()
+  static func cacheCrashContext(session: AwsSession?,
+                                userId: String?,
+                                screenName: String?)
+
+  static func recoverCrashContext(from rawCrash: [String: Any],
+                                  log: LogRecordBuilder,
+                                  attributes: [String: AttributeValue]) -> [String: AttributeValue]
+  static func processStoredCrashes()
+}
+
+public class AwsKSCrashInstrumentation: CrashProtocol {
+  public static let maxStackTraceBytes = 25 * 1024 // 25 KB
+  public private(set) static var isInstalled: Bool = false
+  private static let logger = OpenTelemetry.instance.loggerProvider.get(instrumentationScopeName: AwsInstrumentationScopes.KSCRASH)
+  static let reporter = KSCrash.shared
+  static var observers: [NSObjectProtocol] = []
+  private static let queue = DispatchQueue(label: AwsInstrumentationScopes.KSCRASH, qos: .utility)
+  private static let timestampFormatter: ISO8601DateFormatter = {
+    // Example KSCrash timestamp: `2025-10-28T03:30:53.604204Z`
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [
+      .withInternetDateTime,
+      .withFractionalSeconds
+    ]
+    return formatter
+  }()
+
+  static func install() {
+    guard !isInstalled else {
+      AwsOpenTelemetryLogger.debug("AwsKSCrashInstrumentation already installed")
+      return
+    }
+
+    do {
+      let config = KSCrashConfiguration()
+      config.enableSigTermMonitoring = false
+      config.enableSwapCxaThrow = false
+
+      try reporter.install(with: config)
+      isInstalled = true
+      AwsOpenTelemetryLogger.debug("installed")
+    } catch {
+      AwsOpenTelemetryLogger.error("AwsKSCrashInstrumentation failed to install: \(error)")
+      return
+    }
+
+    // Set initial user info
+    cacheCrashContext()
+
+    // Process any stored crashes asynchronously
+    queue.async {
+      processStoredCrashes()
+    }
+
+    // setup cache context subscribers
+    setupNotificationObservers()
+  }
+
+  static func setupNotificationObservers() {
+    // Update crash context on session start
+    let sessionObserver = NotificationCenter.default.addObserver(
+      forName: SessionStartNotification,
+      object: nil,
+      queue: nil
+    ) { notification in
+      if let session = notification.object as? AwsSession {
+        queue.async {
+          cacheCrashContext(session: session)
+        }
+      }
+    }
+    observers.append(sessionObserver)
+
+    // Update crash context on user change
+    let userObserver = NotificationCenter.default.addObserver(
+      forName: AwsUserIdChangeNotification,
+      object: nil,
+      queue: nil
+    ) { notification in
+      if let userId = notification.object as? String {
+        queue.async {
+          cacheCrashContext(session: nil, userId: userId)
+        }
+      }
+    }
+    observers.append(userObserver)
+
+    // Update crash context on screen change
+    let screenObserver = NotificationCenter.default.addObserver(
+      forName: AwsScreenChangeNotification,
+      object: nil,
+      queue: nil
+    ) { notification in
+      if let screen = notification.object as? String {
+        queue.async {
+          cacheCrashContext(session: nil, userId: nil, screenName: screen)
+        }
+      }
+    }
+    observers.append(screenObserver)
+  }
+
+  static func cacheCrashContext(session: AwsSession? = nil,
+                                userId: String? = nil,
+                                screenName: String? = nil) {
+    var userInfo: [String: Any] = [:]
+
+    // user
+    let userId = userId ?? AwsUIDManagerProvider.getInstance().getUID()
+    userInfo[AwsUserSemvConv.id] = userId
+
+    // session
+    let sessionManager = AwsSessionManagerProvider.getInstance()
+    if let session = session ?? sessionManager.peekSession() {
+      userInfo[AwsSessionSemConv.id] = session.id
+      if let prevSessionId = session.previousId {
+        userInfo[AwsSessionSemConv.previousId] = prevSessionId
+      }
+    }
+
+    // screen
+    if let screen = screenName {
+      userInfo[AwsViewSemConv.screenName] = screen
+    }
+
+    reporter.userInfo = userInfo
+  }
+
+  /// Report cached crashes from KSCrash store (just a local file)
+  static func processStoredCrashes() {
+    // Init
+    guard let reportStore = reporter.reportStore else {
+      AwsOpenTelemetryLogger.debug("AwsKSCrashInstrumentation no report store available")
+      return
+    }
+
+    // Pull crash reports
+    let reportIDs = reportStore.reportIDs
+    for reportID in reportIDs {
+      guard let id = reportID as? Int64,
+            let crashReport = reportStore.report(for: id) else {
+        AwsOpenTelemetryLogger.debug("AwsKSCrashInstrumentation failed to load crash report \(reportID)")
+        continue
+      }
+
+      // Report crash as log event
+      reportCrash(crashReport: crashReport)
+
+      // Delete processed report
+      reportStore.deleteReport(with: id)
+    }
+
+    AwsOpenTelemetryLogger.debug("AwsKSCrashInstrumentation processed \(reportIDs.count) stored crashes")
+  }
+
+  // Report a KSCrash report in Apple format
+  private static func reportCrash(crashReport: CrashReportDictionary) {
+    let rawCrash: [String: Any] = crashReport.value
+    let log: any LogRecordBuilder = logger.logRecordBuilder()
+      .setEventName(AwsCrashSemConv.name)
+
+    var attributes: [String: AttributeValue] = [
+      AwsCrashSemConv.type: AttributeValue.string("crash"),
+      // When `recovered_context` is true, then the following original attributes will be recovered,
+      // and the crash event will be backfilled to the original session.
+      // 1. `session.id`
+      // 2. `session.previous_id` (if any existed)
+      // 3. `user.id`
+      // 4. original `timestamp`
+      AwsCrashSemConv.recoveredContext: AttributeValue.bool(false)
+    ]
+
+    // Attempt to recovert the original crash context
+    attributes = recoverCrashContext(from: rawCrash, log: log, attributes: attributes)
+
+    // Get stack trace in Apple format and emit log event in async callback
+    // If the iOS application was built with `strip styles` set to `debugging symbols`, then KSCrash will
+    // also perform on-device symbolication.
+    CrashReportFilterAppleFmt().filterReports([crashReport]) { reports, _ in
+      var appleFormatReport = (reports?.first as? CrashReportString)?.value ?? "Failed to format crash report"
+      if appleFormatReport.utf8.count > maxStackTraceBytes {
+        appleFormatReport = String(appleFormatReport.utf8.prefix(maxStackTraceBytes)) ?? appleFormatReport
+      }
+      attributes[AwsCrashSemConv.stacktrace] = AttributeValue.string(appleFormatReport)
+
+      // Prints the location of the first frame for the thread that crashed. For example,
+      // `Crash detected on thread 0 at libswiftCore.dylib 0x000000019ed5c8c4 $ss17_assertionFailure__4file4line5flagss5NeverOs12StaticStringV_SSAHSus6UInt32VtF + 172`
+      attributes[AwsCrashSemConv.message] = AttributeValue.string(extractCrashMessage(from: appleFormatReport))
+
+      _ = log.setAttributes(attributes)
+      log.emit()
+    }
+  }
+
+  /// Get exception code information for the crash message. This is useful for grouping
+  static func extractCrashMessage(from stackTrace: String) -> String {
+    let lines = stackTrace.components(separatedBy: "\n")
+
+    // Look for exception type and codes
+    if let exceptionTypeLine = lines.first(where: { $0.hasPrefix("Exception Type:") }),
+       let exceptionCodesLine = lines.first(where: { $0.hasPrefix("Exception Codes:") }) {
+      let exceptionType = exceptionTypeLine.replacingOccurrences(of: "Exception Type:", with: "")
+        .trimmingCharacters(in: .whitespaces)
+      let exceptionCodes = exceptionCodesLine.replacingOccurrences(of: "Exception Codes:", with: "")
+        .trimmingCharacters(in: .whitespaces)
+
+      return "\(exceptionType): \(exceptionCodes)"
+    }
+
+    // Fallback to thread and first frame if exception codes not found
+    guard let crashedLine = lines.first(where: { $0.range(of: #"Thread \d+ Crashed:"#, options: .regularExpression) != nil }),
+          let threadMatch = crashedLine.range(of: #"Thread (\d+) Crashed:"#, options: .regularExpression),
+          let crashedIndex = lines.firstIndex(of: crashedLine),
+          let firstFrame = lines.dropFirst(crashedIndex + 1).first(where: { $0.hasPrefix("0   ") }) else {
+      return "Crash detected at unknown location"
+    }
+
+    let threadNumber = String(crashedLine[threadMatch]).replacingOccurrences(of: #"Thread (\d+) Crashed:"#, with: "$1", options: .regularExpression)
+    let cleanFrame = String(firstFrame.dropFirst(2)) // Remove "0 " prefix
+      .replacingOccurrences(of: #"[\s\t]+"#, with: " ", options: .regularExpression) // reduce white spaces to single spaces
+      .trimmingCharacters(in: .whitespaces) // trim white spaces
+    return "Crash detected on thread \(threadNumber) at \(cleanFrame)"
+  }
+
+  /// If sessionId and timestamp can be recovered, then attempt to restore original context.
+  /// However, if user session context cannot be recovered, then we use the current timestamp
+  /// and let sessions/user id processors do their work. For this edge case, users can look
+  /// at the current `session.previous_id` to see if the previous session had crashed.
+  static func recoverCrashContext(from rawCrash: [String: Any],
+                                  log: LogRecordBuilder,
+                                  attributes: [String: AttributeValue]) -> [String: AttributeValue] {
+    guard let report = rawCrash["report"] as? [String: Any],
+          let timestampString = report["timestamp"] as? String,
+          let timestamp = timestampFormatter.date(from: timestampString),
+          let userInfo = rawCrash["user"] as? [String: Any],
+          let sessionId = userInfo[AwsSessionSemConv.id] as? String else {
+      _ = log.setTimestamp(Date()) // just for clarity (upstream already does this)
+      AwsOpenTelemetryLogger.debug("AwsKSCrashInstrumentation failed to recover crash context")
+      return attributes
+    }
+    var mutatedAttributes = attributes
+
+    // required attributes for recovery
+    _ = log.setTimestamp(timestamp)
+    mutatedAttributes[AwsSessionSemConv.id] = AttributeValue.string(sessionId)
+
+    // `user.id` is only nice-to-have for crash recovery, so we will grab it without blocking the overall recovery attempt
+    if let userId = userInfo[AwsUserSemvConv.id] as? String {
+      mutatedAttributes[AwsUserSemvConv.id] = AttributeValue.string(userId)
+    }
+
+    // `screen.name` is also nice-to-have, and may not exist if a screen had not been registered at the time
+    if let screenName = userInfo[AwsViewSemConv.screenName] as? String {
+      mutatedAttributes[AwsViewSemConv.screenName] = AttributeValue.string(screenName)
+    }
+
+    // `session.previous_id` is also nice-to-have, and may not even exist if there was no previous session
+    if let previousSessionId = userInfo[AwsSessionSemConv.previousId] as? String {
+      mutatedAttributes[AwsSessionSemConv.previousId] = AttributeValue.string(previousSessionId)
+    }
+
+    // Confirms that original context was recovered, since this may not be obvious
+    mutatedAttributes[AwsCrashSemConv.recoveredContext] = AttributeValue.bool(true)
+    return mutatedAttributes
+  }
+}

--- a/Sources/AwsOpenTelemetryCore/SwiftUI/AwsViewSemConv.swift
+++ b/Sources/AwsOpenTelemetryCore/SwiftUI/AwsViewSemConv.swift
@@ -1,0 +1,38 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import Foundation
+
+enum AwsViewType: String, CaseIterable {
+  case uikit
+  case swiftui
+}
+
+public class AwsViewSemConv {
+  static let screenName = "screen.name"
+  static let type = "app.screen.type"
+}
+
+public class AwsViewDidAppearSemConv: AwsViewSemConv {
+  static let name = "app.screen.view_did_appear"
+  static let interaction = "app.screen.interaction"
+  static let parentName = "app.screen.parent_screen.name"
+}
+
+public class AwsTimeToFirstAppearSemConv: AwsViewSemConv {
+  static let name = "app.screen.time_to_first_appear"
+}
+
+public let AwsScreenChangeNotification = Notification.Name("software.amazon.opentelemetry.ScreenChange")

--- a/Tests/AwsOpenTelemetryCoreTests/Constants/AwsInstrumentationScopesTests.swift
+++ b/Tests/AwsOpenTelemetryCoreTests/Constants/AwsInstrumentationScopesTests.swift
@@ -36,4 +36,8 @@ final class AwsInstrumentationScopesTests: XCTestCase {
   func testHangs() {
     XCTAssertEqual(AwsInstrumentationScopes.HANG, "software.amazon.opentelemetry.Hang")
   }
+
+  func testKSCrash() {
+    XCTAssertEqual(AwsInstrumentationScopes.KSCRASH, "software.amazon.opentelemetry.kscrash")
+  }
 }

--- a/Tests/AwsOpenTelemetryCoreTests/KSCrash/AwsKSCrashInstrumentationTests.swift
+++ b/Tests/AwsOpenTelemetryCoreTests/KSCrash/AwsKSCrashInstrumentationTests.swift
@@ -1,0 +1,324 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import XCTest
+import OpenTelemetrySdk
+import OpenTelemetryApi
+@testable import AwsOpenTelemetryCore
+@testable import TestUtils
+
+#if canImport(KSCrash)
+  import KSCrash
+#endif
+
+final class AwsKSCrashInstrumentationTests: XCTestCase {
+  private var inMemoryExporter: InMemoryLogExporter!
+
+  override func setUp() {
+    super.setUp()
+    inMemoryExporter = InMemoryLogExporter.register()
+  }
+
+  override func tearDown() {
+    inMemoryExporter.reset()
+    NotificationCenter.default.removeObserver(self)
+    super.tearDown()
+  }
+
+  func testCacheCrashContext() {
+    let session = AwsSession(
+      id: "cache-session-id",
+      expireTime: Date(timeIntervalSinceNow: 1800),
+      previousId: "cache-prev-id"
+    )
+
+    AwsKSCrashInstrumentation.cacheCrashContext(session: session)
+
+    let userInfo = AwsKSCrashInstrumentation.reporter.userInfo as? [String: String]
+    XCTAssertEqual(userInfo?[AwsSessionSemConv.id], "cache-session-id")
+    XCTAssertEqual(userInfo?[AwsSessionSemConv.previousId], "cache-prev-id")
+    XCTAssertNotNil(userInfo?["user.id"])
+  }
+
+  func testReporterConfiguration() {
+    XCTAssertNotNil(AwsKSCrashInstrumentation.reporter)
+  }
+
+  func testMaxStackTraceBytes() {
+    XCTAssertEqual(AwsKSCrashInstrumentation.maxStackTraceBytes, 25 * 1024)
+  }
+
+  func testExtractCrashMessageWithExceptionCodes() {
+    let stackTrace = """
+    Incident Identifier: 3F2AFC2A-DA05-465B-BD41-436FC333127A
+    CrashReporter Key:   2d7a9903541465dabf265effbee827cd9e6da6e1
+    Hardware Model:      iPhone15,4
+    Process:             AwsHackerNewsDemo [680]
+    Path:                /private/var/containers/Bundle/Application/83BD3EA1-BE39-4D4A-A88E-06ADA0466843/AwsHackerNewsDemo.app/AwsHackerNewsDemo
+    Identifier:          AwsHackerNewsDemo
+    Version:             1.0 (19)
+    Code Type:           ARM-64 (Native)
+    Role:                Foreground
+    Parent Process:      launchd [1]
+
+    Date/Time:           2025-11-06 15:12:20.759 -0800
+    OS Version:          iOS 18.6 (22G86)
+    Report Version:      104
+
+    Exception Type:  EXC_BREAKPOINT (SIGTRAP)
+    Exception Codes: KERN_INVALID_ADDRESS at 0x000000019bd6c8c4
+    Triggered by Thread:  0
+    """
+
+    let result = AwsKSCrashInstrumentation.extractCrashMessage(from: stackTrace)
+    XCTAssertEqual(result, "EXC_BREAKPOINT (SIGTRAP): KERN_INVALID_ADDRESS at 0x000000019bd6c8c4")
+  }
+
+  func testExtractCrashMessageWithBadAccess() {
+    let stackTrace = """
+    Exception Type:  EXC_BAD_ACCESS (SIGSEGV)
+    Exception Codes: KERN_INVALID_ADDRESS at 0xffffffff
+    """
+
+    let result = AwsKSCrashInstrumentation.extractCrashMessage(from: stackTrace)
+    XCTAssertEqual(result, "EXC_BAD_ACCESS (SIGSEGV): KERN_INVALID_ADDRESS at 0xffffffff")
+  }
+
+  func testExtractCrashMessageFallbackToThread() {
+    let stackTrace = """
+    Thread 0 Crashed:
+    0   libswiftCore.dylib            \t0x000000019ed5c8c4 $ss17_assertionFailure__4file4line5flagss5NeverOs12StaticStringV_SSAHSus6UInt32VtF + 172
+    1   libswiftCore.dylib            \t0x000000019ed5c8c4 $ss17_assertionFailure__4file4line5flagss5NeverOs12StaticStringV_SSAHSus6UInt32VtF + 172
+    """
+
+    let result = AwsKSCrashInstrumentation.extractCrashMessage(from: stackTrace)
+    XCTAssertEqual(result, "Crash detected on thread 0 at libswiftCore.dylib 0x000000019ed5c8c4 $ss17_assertionFailure__4file4line5flagss5NeverOs12StaticStringV_SSAHSus6UInt32VtF + 172")
+  }
+
+  func testExtractCrashMessageFallbackWithDifferentThread() {
+    let stackTrace = """
+    Thread 5 Crashed:
+    0   SomeFramework                 \t0x00000001f14e1a90 someFunction + 8
+    """
+
+    let result = AwsKSCrashInstrumentation.extractCrashMessage(from: stackTrace)
+    XCTAssertEqual(result, "Crash detected on thread 5 at SomeFramework 0x00000001f14e1a90 someFunction + 8")
+  }
+
+  func testExtractCrashMessageEdgeCases() {
+    XCTAssertEqual(AwsKSCrashInstrumentation.extractCrashMessage(from: ""), "Crash detected at unknown location")
+    XCTAssertEqual(AwsKSCrashInstrumentation.extractCrashMessage(from: "Thread Crashed:\n0   SomeFramework"), "Crash detected at unknown location")
+
+    let noThreadCrashed = "Some other content\nThread 1:\n0   libsystem_kernel.dylib"
+    XCTAssertEqual(AwsKSCrashInstrumentation.extractCrashMessage(from: noThreadCrashed), "Crash detected at unknown location")
+  }
+
+  func testExtractCrashMessageWithWhitespaceHandling() {
+    let stackTrace = """
+    Thread 2 Crashed:
+    0     MyFramework     \t\t\t    0x123456789    myFunction    +    123
+    """
+
+    let result = AwsKSCrashInstrumentation.extractCrashMessage(from: stackTrace)
+    XCTAssertEqual(result, "Crash detected on thread 2 at MyFramework 0x123456789 myFunction + 123")
+  }
+
+  func testExtractCrashMessageWithExceptionCodesOnly() {
+    let stackTrace = """
+    Exception Type:  EXC_CRASH (SIGABRT)
+    Exception Codes: 0x0000000000000000
+    """
+
+    let result = AwsKSCrashInstrumentation.extractCrashMessage(from: stackTrace)
+    XCTAssertEqual(result, "EXC_CRASH (SIGABRT): 0x0000000000000000")
+  }
+
+  func testExtractCrashMessageWithPartialExceptionInfo() {
+    let stackTrace = """
+    Exception Type:  EXC_BREAKPOINT (SIGTRAP)
+    Thread 0 Crashed:
+    0   SomeFramework                 0x123456789 someFunction + 8
+    """
+
+    // Should fallback to thread info when exception codes are missing
+    let result = AwsKSCrashInstrumentation.extractCrashMessage(from: stackTrace)
+    XCTAssertEqual(result, "Crash detected on thread 0 at SomeFramework 0x123456789 someFunction + 8")
+  }
+
+  func testRecoverCrashContextSuccess() {
+    let mockLogBuilder = MockLogRecordBuilder()
+    let initialAttributes: [String: AttributeValue] = [
+      "exception.type": AttributeValue.string("crash"),
+      "recovered_context": AttributeValue.bool(false)
+    ]
+
+    let rawCrash: [String: Any] = [
+      "report": ["timestamp": "2025-10-28T21:38:55.554842Z"],
+      "user": [
+        AwsSessionSemConv.id: "test-session-id",
+        AwsSessionSemConv.previousId: "test-prev-session-id",
+        "user.id": "test-user-id"
+      ]
+    ]
+
+    let result = AwsKSCrashInstrumentation.recoverCrashContext(
+      from: rawCrash,
+      log: mockLogBuilder,
+      attributes: initialAttributes
+    )
+
+    XCTAssertEqual(result["recovered_context"]?.description, "true")
+    XCTAssertEqual(result[AwsSessionSemConv.id]?.description, "test-session-id")
+    XCTAssertEqual(result[AwsSessionSemConv.previousId]?.description, "test-prev-session-id")
+    XCTAssertEqual(result["user.id"]?.description, "test-user-id")
+  }
+
+  func testRecoverCrashContextFailureCases() {
+    let mockLogBuilder = MockLogRecordBuilder()
+    let initialAttributes: [String: AttributeValue] = ["recovered_context": AttributeValue.bool(false)]
+
+    var result = AwsKSCrashInstrumentation.recoverCrashContext(from: [:], log: mockLogBuilder, attributes: initialAttributes)
+    XCTAssertEqual(result["recovered_context"]?.description, "false")
+    XCTAssertNil(result[AwsSessionSemConv.id])
+
+    let crashWithoutUser = ["report": ["timestamp": "2025-10-28T21:38:55.554842Z"]]
+    result = AwsKSCrashInstrumentation.recoverCrashContext(from: crashWithoutUser, log: mockLogBuilder, attributes: initialAttributes)
+    XCTAssertEqual(result["recovered_context"]?.description, "false")
+
+    let crashWithInvalidTimestamp = [
+      "report": ["timestamp": "invalid-timestamp"],
+      "user": [AwsSessionSemConv.id: "test-session-id"]
+    ]
+    result = AwsKSCrashInstrumentation.recoverCrashContext(from: crashWithInvalidTimestamp, log: mockLogBuilder, attributes: initialAttributes)
+    XCTAssertEqual(result["recovered_context"]?.description, "false")
+  }
+
+  func testRecoverCrashContextPartialUserInfo() {
+    let mockLogBuilder = MockLogRecordBuilder()
+    let initialAttributes: [String: AttributeValue] = ["recovered_context": AttributeValue.bool(false)]
+
+    let rawCrash: [String: Any] = [
+      "report": ["timestamp": "2025-10-28T21:38:55.554842Z"],
+      "user": [AwsSessionSemConv.id: "test-session-id"]
+    ]
+
+    let result = AwsKSCrashInstrumentation.recoverCrashContext(
+      from: rawCrash,
+      log: mockLogBuilder,
+      attributes: initialAttributes
+    )
+
+    XCTAssertEqual(result["recovered_context"]?.description, "true")
+    XCTAssertEqual(result[AwsSessionSemConv.id]?.description, "test-session-id")
+    XCTAssertNil(result[AwsSessionSemConv.previousId])
+    XCTAssertNil(result["user.id"])
+  }
+
+  func testRecoverCrashContextWithOptionalFields() {
+    let mockLogBuilder = MockLogRecordBuilder()
+    let initialAttributes: [String: AttributeValue] = ["recovered_context": AttributeValue.bool(false)]
+
+    let rawCrash: [String: Any] = [
+      "report": ["timestamp": "2025-10-28T21:38:55.554842Z"],
+      "user": [
+        AwsSessionSemConv.id: "test-session-id",
+        AwsViewSemConv.screenName: "TestScreen"
+      ]
+    ]
+
+    let result = AwsKSCrashInstrumentation.recoverCrashContext(
+      from: rawCrash,
+      log: mockLogBuilder,
+      attributes: initialAttributes
+    )
+
+    XCTAssertEqual(result["recovered_context"]?.description, "true")
+    XCTAssertEqual(result[AwsViewSemConv.screenName]?.description, "TestScreen")
+  }
+
+  func testCacheCrashContextVariations() {
+    AwsKSCrashInstrumentation.cacheCrashContext(session: nil, userId: nil, screenName: nil)
+
+    let session = AwsSession(id: "specific-session", expireTime: Date(timeIntervalSinceNow: 1800))
+    AwsKSCrashInstrumentation.cacheCrashContext(session: session, userId: "specific-user", screenName: "SpecificScreen")
+    let userInfo = AwsKSCrashInstrumentation.reporter.userInfo as? [String: String]
+
+    // assert
+    XCTAssertEqual(userInfo?[AwsSessionSemConv.id], "specific-session")
+    XCTAssertEqual(userInfo?[AwsUserSemvConv.id], "specific-user")
+    XCTAssertEqual(userInfo?[AwsViewSemConv.screenName], "SpecificScreen")
+  }
+
+  func testNotificationHandling() {
+    AwsKSCrashInstrumentation.setupNotificationObservers()
+    defer {
+      for observer in AwsKSCrashInstrumentation.observers {
+        NotificationCenter.default.removeObserver(observer)
+      }
+      AwsKSCrashInstrumentation.observers.removeAll()
+    }
+
+    let session = AwsSession(id: "notification-session", expireTime: Date(timeIntervalSinceNow: 1800))
+    NotificationCenter.default.post(name: SessionStartNotification, object: session)
+
+    let expectation = XCTestExpectation(description: "Async crash context update")
+    DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.1) {
+      expectation.fulfill()
+    }
+    wait(for: [expectation], timeout: 1.0)
+
+    let userInfo = AwsKSCrashInstrumentation.reporter.userInfo as? [String: String]
+    XCTAssertEqual(userInfo?[AwsSessionSemConv.id], "notification-session")
+  }
+
+  func testInstallMethod() {
+    XCTAssertNoThrow(AwsKSCrashInstrumentation.install())
+  }
+
+  func testProcessStoredCrashes() {
+    XCTAssertNoThrow(AwsKSCrashInstrumentation.processStoredCrashes())
+  }
+}
+
+class MockLogRecordBuilder: LogRecordBuilder {
+  var timestamp: Date?
+  var attributes: [String: AttributeValue] = [:]
+  var eventName: String?
+
+  func setTimestamp(_ timestamp: Date) -> LogRecordBuilder {
+    self.timestamp = timestamp
+    return self
+  }
+
+  func setObservedTimestamp(_ timestamp: Date) -> LogRecordBuilder { return self }
+  func setEventName(_ name: String) -> LogRecordBuilder {
+    eventName = name
+    return self
+  }
+
+  func setSeverity(_ severity: Severity) -> LogRecordBuilder { return self }
+  func setBody(_ body: AttributeValue) -> LogRecordBuilder { return self }
+  func setAttributes(_ attributes: [String: AttributeValue]) -> LogRecordBuilder {
+    self.attributes = attributes
+    return self
+  }
+
+  func addAttribute(key: String, value: AttributeValue) -> LogRecordBuilder {
+    attributes[key] = value
+    return self
+  }
+
+  func emit() {}
+}


### PR DESCRIPTION
## Summary

The MxCrashDiagnostic seems to be the only reliably reported diagnostic payload from metric kit, so we should continue to support it as a backup method. However, the call stack tree format is not very human readable, and causes issues with payload size since you cannot exactly truncate a json file while guaranteeing that it'll remain valid JSON. To get unblocked on that, we onboarded to shaking the tree until its within an acceptable size, but that obviously has its issues too. Symbolicating call stack trees also seems painful, since there is no native way besides using custom tools provided by third parties. 

Instead, seems that KSCrash is a significantly better choice, since it supports standard apple crash format. It also supports on-device symbolication if the app developer chooses to set strip styles settings to debugging symbols during production, which allegedly causes a ~5% impact on binary sizes

## Implementation

I've done basic onboarding to KSCrash reporter. One improvement I added was adding the following crash context so that the crashes are reported with its original `timestamp`, `session.id`, `user.id`, and `session.previous_id`. However, if the original context cannot be recovered, then the crashes will be reported with their observed timestamps during the next app launch.

## Test

As you can see here, the crash is backfilled to its original location next to the [DEBUG] statement indicating a manual crash was triggered, even though in reality is was recovered after the next AppStart (cold launch) event. 

<img width="773" height="388" alt="Screenshot 2025-10-29 at 12 17 31 AM" src="https://github.com/user-attachments/assets/fdfd99c5-09c2-434c-96d9-b1a294e05ff8" />

```jsonc
{
  "account_id": "609391207627",
  "application_id": "927baf95-96e9-412b-8126-3c3875669c66",
  "application_name": "AwsRumDemo",
  "sessionId": "AD2E08D1-EB7A-45F9-9140-F08220546170",
  "userId": "82E85CD0-1CD5-4726-B2A9-7127C9CA9A1C",
  "event_timestamp": 1761722084184,
  "traceId": "",
  "spanId": "",
  "flags": 0,
  "attributes": {
    "session.previous_id": "89BA6233-982A-42CA-BC2C-8ED6EE9A9110",
    "user.id": "82E85CD0-1CD5-4726-B2A9-7127C9CA9A1C",
    "exception.type": "crash",
    "exception.message": "Crash detected on thread 0 at libswiftCore.dylib 0x000000019ed5c8c4 $ss17_assertionFailure__4file4line5flagss5NeverOs12StaticStringV_SSAHSus6UInt32VtF + 172",
    "recovered_context": true,
    "exception.stacktrace": "Incident Identifier: 5FDC9323-4337-4EE3-A311-8FF19022CF64\nCrashReporter Key:   c20e441eb6b7d2f065ce13a79ebd2068935284ca\nHardware Model:      iPhone17,2\nProcess:             AwsHackerNewsDemo [32521]\nPath:                /private/var/containers/Bundle/Application/DB81B5E6-F8C9-4E16-AED5-E588CFADBA19/AwsHackerNewsDemo.app/AwsHackerNewsDemo\nIdentifier:          AwsHackerNewsDemo\nVersion:             1.0 (3)\nCode Type:           ARM-64 (Native)\nRole:                Foreground\nParent Process:      launchd [1]\n\nDate/Time:           2025-10-29 00:14:44.185 -0700\nOS Version:          iOS 18.6.2 (22G100)\nReport Version:      104\n\nException Type:  EXC_BREAKPOINT (SIGTRAP)\nException Codes: KERN_INVALID_ADDRESS at 0x000000019ed5c8c4\nTriggered by Thread:  0\n\nThread 0 Crashed:\n0   libswiftCore.dylib            \t0x000000019ed5c8c4 $ss17_assertionFailure__4file4line5flagss5NeverOs12StaticStringV_SSAHSus6UInt32VtF + 172\n1   libswiftCore.dylib            \t0x000000019ed5c8c4 $ss17_assertionFailure__4file4line5flagss5NeverOs12StaticStringV_SSAHSus6UInt32VtF + 172\n2   AwsHackerNewsDemo             \t0x000000010277e5f0 __swift_instantiateConcreteTypeFromMangledNameAbstract + 42572\n3   AwsHackerNewsDemo             \t0x00000001027846b4 block_destroy_helper.132 + 52\n4   libdispatch.dylib             \t0x00000001a862c584 0x1a8611000 + 112004\n5   libdispatch.dylib             \t0x00000001a8617560 0x1a8611000 + 25952\n6   libdispatch.dylib             \t0x00000001a862a348 0x1a8611000 + 103240\n7   libdispatch.dylib             \t0x00000001a8629020 0x1a8611000 + 98336\n8   libdispatch.dylib             \t0x00000001a86494ec 0x1a8611000 + 230636\n9   libdispatch.dylib             \t0x00000001a8621d30 0x1a8611000 + 68912\n10  libdispatch.dylib             \t0x00000001a8621c6c _dispatch_main_queue_callback_4CF + 44\n11  CoreFoundation                \t0x00000001a06e2c30 0x1a0676000 + 445488\n12  CoreFoundation                \t0x00000001a0686394 0x1a0676000 + 66452\n13  CoreFoundation                \t0x00000001a0687adc CFRunLoopRunSpecific + 572\n14  GraphicsServices              \t0x00000001ed4ad454 GSEventRunModal + 168\n15  UIKitCore                     \t0x00000001a30a9274 0x1a2f74000 + 1266292\n16  UIKitCore                     \t0x00000001a3074a28 UIApplicationMain + 336\n17  UIKitCore                     \t0x00000001a3156168 0x1a2f74000 + 1974632\n18  AwsHackerNewsDemo             \t0x00000001027a3c10 main + 116\n19  (null)\t0x00000001c7119f08 0x0 + 7634788104\n\nThread 1:\n0   libsystem_kernel.dylib        \t0x00000001f14e1a90 __workq_kernreturn + 8\n1   libsystem_pthread.dylib       \t0x000000022ab30a58 _pthread_wqthread + 368\n\nThread 2:\n0   libsystem_kernel.dylib        \t0x00000001f14e1a90 __workq_kernreturn + 8\n1   libsystem_pthread.dylib       \t0x000000022ab30a58 _pthread_wqthread + 368\n\nThread 3:\n0   libsystem_pthread.dylib       \t0x000000022ab30aa4 _pthread_wqthread + 444\n\nThread 4:\n0   libsystem_kernel.dylib        \t0x00000001f14e1a90 __workq_kernreturn + 8\n1   libsystem_pthread.dylib       \t0x000000022ab30a58 _pthread_wqthread + 368\n\nThread 5 name:  com.apple.uikit.eventfetch-thread\nThread 5:\n0   libsystem_kernel.dylib        \t0x00000001f14e1ce4 mach_msg2_trap + 8\n1   libsystem_kernel.dylib        \t0x00000001f14e539c mach_msg2_internal + 76\n2   libsystem_kernel.dylib        \t0x00000001f14e52b8 mach_msg_overwrite + 428\n3   libsystem_kernel.dylib        \t0x00000001f14e5100 mach_msg + 24\n4   CoreFoundation                \t0x00000001a06877a0 0x1a0676000 + 71584\n5   CoreFoundation                \t0x00000001a0686090 0x1a0676000 + 65680\n6   CoreFoundation                \t0x00000001a0687adc CFRunLoopRunSpecific + 572\n7   Foundation                    \t0x000000019f2fe79c 0x19f2ef000 + 63388\n8   Foundation                    \t0x000000019f304020 0x19f2ef000 + 86048\n9   UIKitCore                     \t0x00000001a309356c 0x1a2f74000 + 1176940\n10  Foundation                    \t0x000000019f364804 0x19f2ef000 + 481284\n11  libsystem_pthread.dylib       \t0x000000022ab33344 _pthread_start + 136\n\nThread 6:\n0   libsystem_kernel.dylib        \t0x00000001f14e1a90 __workq_kernreturn + 8\n1   libsystem_pthread.dylib       \t0x000000022ab30a58 _pthread_wqthread + 368\n\nThread 7:\n0   libsystem_kernel.dylib        \t0x00000001f14e1a90 __workq_kernreturn + 8\n1   libsystem_pthread.dylib       \t0x000000022ab30a58 _pthread_wqthread + 368\n\nThread 8:\n0   libsystem_kernel.dylib        \t0x00000001f14e7438 __psynch_cvwait + 8\n1   libsystem_pthread.dylib       \t0x000000022ab31e7c 0x22ab30000 + 7804\n2   Foundation                    \t0x000000019f443bcc 0x19f2ef000 + 1395660\n3   AwsHackerNewsDemo             \t0x000000010285094c __swift_memcpy48_8 + 5092\n4   AwsHackerNewsDemo             \t0x0000000102850a14 __swift_memcpy48_8 + 5292\n5   Foundation                    \t0x000000019f364804 0x19f2ef000 + 481284\n6   libsystem_pthread.dylib       \t0x000000022ab33344 _pthread_start + 136\n\nThread 9:\n0   libsystem_kernel.dylib        \t0x00000001f14e7438 __psynch_cvwait + 8\n1   libsystem_pthread.dylib       \t0x000000022ab31e7c 0x22ab30000 + 7804\n2   Foundation                    \t0x000000019f443bcc 0x19f2ef000 + 1395660\n3   AwsHackerNewsDemo             \t0x000000010280b88c __swift_memcpy16_8 + 20248\n4   AwsHackerNewsDemo             \t0x000000010280b954 __swift_memcpy16_8 + 20448\n5   Foundation                    \t0x000000019f364804 0x19f2ef000 + 481284\n6   libsystem_pthread.dylib       \t0x000000022ab33344 _pthread_start + 136\n\nThread 10:\n0   libsystem_kernel.dylib        \t0x00000001f14e7658 __semwait_signal + 8\n1   libsystem_c.dylib             \t0x00000001a866a9ac nanosleep + 220\n2   libsystem_c.dylib             \t0x00000001a867fd10 sleep + 52\n3   AwsHackerNewsDemo             \t0x00000001029c81c0 monitorThreadCache + 748\n4   libsystem_pthread.dylib       \t0x000000022ab33344 _pthread_start + 136\n\nThread 11 name:  KSCrash Exception Handler (Secondary)\nThread 11:\n0   libsystem_kernel.dylib        \t0x00000001f14e1ce4 mach_msg2_trap + 8\n1   libsystem_kernel.dylib        \t0x00000001f14e539c mach_msg2_internal + 76\n2   libsystem_kernel.dylib        \t0x00000001f14e52b8 mach_msg_overwrite + 428\n3   libsystem_kernel.dylib        \t0x00000001f14e5100 mach_msg + 24\n4   AwsHackerNewsDemo             \t0x00000001029c9f80 exceptionHandlerThreadMain + 84\n5   libsystem_pthread.dylib       \t0x000000022ab33344 _pthread_start + 136\n\nThread 12 name:  KSCrash Exception Handler (Primary)\nThread 12:\n0   (null)\t0x0000000000000000 0x0 + 0\n\nThread 13:\n0   libsystem_kernel.dylib        \t0x00000001f14e1ce4 mach_msg2_trap + 8\n1   libsystem_kernel.dylib        \t0x00000001f14e539c mach_msg2_internal + 76\n2   libsystem_kernel.dylib        \t0x00000001f14e52b8 mach_msg_overwrite + 428\n3   libsystem_kernel.dylib        \t0x00000001f14e5100 mach_msg + 24\n4   CoreFoundation                \t0x00000001a06877a0 0x1a0676000 + 71584\n5   CoreFoundation                \t0x00000001a0686090 0x1a0676000 + 65680\n6   CoreFoundation                \t0x00000001a0687adc CFRunLoopRunSpecific + 572\n7   CFNetwork                     \t0x00000001a1cb5db8 0x1a1c16000 + 654776\n8   Foundation                    \t0x000000019f364804 0x19f2ef000 + 481284\n9   libsystem_pthread.dylib       \t0x000000022ab33344 _pthread_start + 136\n\nThread 0 crashed with ARM-64 Thread State:\n    x0: 0x8000000102e6f510     x1: 0xffffffffb0000000     x2: 0x0000000000000058     x3: 0xfffff0007fc00000 \n    x4: 0x0000000000000000     x5: 0x000000016d691ff0     x6: 0x0000000000000067     x7: 0x5ffa0b05777a8c54 \n    x8: 0x0000000000000000     x9: 0x000000007fb7e6fd    x10: 0x0000000000000000    x11: 0x0000000000000000 \n   x12: 0x001bc0dd80481902    x13: 0x001bb0da804810e1    x14: 0x0000000000081800    x15: 0x0000000000000009 \n   x16: 0x952d00010444d020    x17: 0x00000001bb0da8e1    x18: 0x0000000000000000    x19: 0x0000000102783974 \n   x20: 0x0000000116bc9040    x21: 0x0000000000000000    x22: 0x0000000000000110    x23: 0x0000000000000000 \n   x24: 0x0000000000000000    x25: 0x000000020b1dc8a0    x26: 0x000000020b1d9040    x27: 0xffe00040fffffffc \n   x28: 0x000000020b1dc8a0   cpsr: 0x0000000000000000     fp: 0x000000016d692180     lr: 0x000000019ed5c8c4 \n    pc: 0x000000019ed5c8c4     sp: 0x000000016d692100 \n\nBinary Images:\n0x10276c000 - 0x102ff3fff AwsHackerNewsDemo arm64  <64e69aafa4fc3f93be63e1b043f38361> /var/containers/Bundle/Application/DB81B5E6-F8C9-4E16-AED5-E588CFADBA19/AwsHackerNewsDemo.app/AwsHackerNewsDemo\n0x103614000 - 0x10361ffff libobjc-trampolines.dylib arm64e  <def9fca06da1332796903b879ffc755c> /private/preboot/Cryptexes/OS/usr/lib/libobjc-trampolines.dylib\n0x19dbf8000 - 0x19dc49bb3 libobjc.A.dylib arm64e  <e8825548d1483ee2807639ea9cb11129> /usr/lib/libobjc.A.dylib\n0x19dc4a000 - 0x19ed2867f MetalPerformanceShadersGraph arm64e  <a017ca39559b3e398eececa17c2181da> /System/Library/Frameworks/MetalPerformanceShadersGraph.framework/MetalPerformanceShadersGraph\n0x19ed29000 - 0x19f29229f libswiftCore.dylib arm64e  <4a7bace5ee57375ab860cd7f1ca9e6af> /usr/lib/swift/libswiftCore.dylib\n0x19f293000 - 0x19f2bafff libswiftPrespecialized.dylib arm64e  <d9d0e8b9809a3bf0861f605735d6c20f> /usr/lib/libswiftPrespecialized.dylib\n0x19f2bb000 - 0x19f2eef7f CoreServicesInternal arm64e  <c974747eeb2932d5bc2416090ad79d08> /System/Library/PrivateFrameworks/CoreServicesInternal.framework/CoreServicesInternal\n0x19f2ef000 - 0x19ff6305f Foundation arm64e  <c031896b2ef13d89966a0b52d54bceee> /System/Library/Frameworks/Foundation.framework/Foundation\n0x19ff64000 - 0x1a01d5c3f WebGPU arm64e  <600d242653293382857b7e1768c26f5b> /System/Library/PrivateFrameworks/WebGPU.framework/WebGPU\n0x1a01d6000 - 0x1a043067f Metal arm64e  <1bf8c468258d302fb1edfab3291b90f7> /System/Library/Frameworks/Metal.framework/Metal\n0x1a0431000 - 0x1a0675f7f CoreServices arm64e  <40effdfff21c3ff3b8b0a1275591d31d> /System/Library/Frameworks/CoreServices.framework/CoreServices\n0x1a0676000 - 0x1a0bf2fff CoreFoundation arm64e  <ae3c93380166397a9643356b14f6ee58> /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation\n0x1a0bf3000 - 0x1a1c1575f Network arm64e  <d722be9e094c3f07a0b2045b9538f523> /System/Library/Frameworks/Network.framework/Network\n0x1a1c16000 - 0x1a1fdb35f CFNetwork arm64e  <271cab2fd622384c8a7f2b5857119e0d> /System/Library/Frameworks/CFNetwork.framework/CFNetwork\n0x1a1fdc000 - 0x1a21fc83f CoreTelephony arm64e  <075772c9f3df3f2f8d53008eed17d8b5> /System/Library/Frameworks/CoreTelephony.framework/CoreTelephony\n0x1a21fd000 - 0x1a25b769f QuartzCore arm64e  <84083889ad8a3201a2683e06b01014f9> /System/Library/Frameworks/QuartzCore.framework/QuartzCore\n0x1a25b8000 - 0x1a27aeddf CoreText arm64e  <dc78990aa3843d7da28d077c218af501> /System/Library/Frameworks/CoreText.framework/CoreText\n0x1a27af000 - 0x1a2eb5e5f CoreGraphics arm64e  <fb10b1178497383aa37ff4a4cc275ae3> /System/Library/Frameworks/CoreGraphics.framework/CoreGraphics\n0x1a2f74000 - 0x1a4eb655f UIKitCore arm64e  <5e794caa41623ff6861e45f29f6b8ac0> /System/Library/PrivateFrameworks/UIKitCore.framework/UIKitCore\n0x1a4eb7000 - 0x1a613a7bf SwiftUI arm64e  <431499857d90345d8c31b764e66e9c4e> /System/Library/Frameworks/SwiftUI.framework/SwiftUI\n0x1a613b000 - 0x1a670fb1f ImageIO arm64e  <ac0dcb11913c375eb6979ca038d34330> /System/Library/Frameworks/ImageIO.framework/ImageIO\n0x1a6710000 - 0x1a6a4e3cf vImage arm64e  <bf3c5537d43039c1adce3a39f1dbb81a> /System/Library/Frameworks/Accelerate.framework/Frameworks/vImage.framework/vImage\n0x1a6a4f000 - 0x1a861003f GeoServices arm64e  <0cf2ccb19c2437e7b09ad1689b4da118> /System/Library/PrivateFrameworks/GeoServices.framework/GeoServices\n0x1a8611000 - 0x1a8656b3f libdispatch.dylib arm64e  <b62778f758273a7ba96da24f7be95416> /usr/lib/system/libdispatch.dylib\n0x1a8657000 - 0x1a86d66c3 libsystem_c.dylib arm64e  <335cd87d234b3fc182db943350d31a88> /usr/lib/system/libsystem_c.dylib\n0x1a86d7000 - 0x1a86d9fcf libsystem_coreservices.dylib arm64e  <477e7f30ddb632b2a9de418669eade6e> /usr/lib/system/libsystem_coreservices.dylib\n0x1a86da000 - 0x1a86db11f AggregateDictionary arm64e  <7abadd23ba0f3a7ca887bfb89365e067> /System/Library/PrivateFrameworks/AggregateDictionary.framework/AggregateDictionary\n0x1a86dc000 - 0x1a8779a9f BackBoardServices arm64e  <4352a6e9a4fa30a29bf166c69b9d6e26> /System/Library/PrivateFrameworks/BackBoardServices.framework/BackBoardServices\n0x1a877a000 - 0x1a885343f BaseBoard arm64e  <c7b632dc3e053a77becb951986fd7284> /System/Library/PrivateFrameworks/BaseBoard.framework/BaseBoard\n0x1a8854000 - 0x1a8c4c97f CoreData arm64e  <80d683c7b7913f9398f7e53306d5f056> /System/Library/Frameworks/CoreData.framework/CoreData\n0x1a8c4d000 - 0x1a8fd975f CloudKit arm64e  <2decd965a6e03fecaab3b3aa40d00811> /System/Library/Frameworks/CloudKit.framework/CloudKit\n0x1a8fda000 - 0x1a91b483f Security arm64e  <8a4b0e75c8f33bcba4f64794061054fa> /System/Library/Frameworks/Security.framework/Security\n0x1a91b5000 - 0x1a9279c3f IOKit arm64e  <04f7d95643f83abe9fe1029087d6c97d> /System/Library/Frameworks/IOKit.framework/Versions/A/IOKit\n0x1a9372000 - 0x1a982691f ContactsUI arm64e  <41e7904a44a53c5993f9d23928fc4ab2> /System/Library/Frameworks/ContactsUI.framework/ContactsUI\n0x1a9b5e000 - 0x1a9cf078b ColorSync arm64e  <cfd33aa36ef53090863fb27839b79959> /System/Library/Frameworks/ColorSync.framework/ColorSync\n0x1a9cf1000 - 0x1a9d07560 libswiftDispatch.dylib arm64e  <28babaed25ca3448be8a30aff6324646> /usr/lib/swift/libswiftDispatch.dylib\n0x1a9dcc000 - 0x1a9ec1a07 Combine arm64e  <9520be0dd3bb3bdc85e11232228f9074> /System/Library/Frameworks/Combine.framework/Combine\n0x1a9ec2000 - 0x1a9edf4df SharedWithYouCore arm64e  <06598bb859993654974fdb370fae28f7> /System/Library/Frameworks/SharedWithYouCore.framework/SharedWithYouCore\n0x1aa501000 - 0x1aa501367 libswiftUIKit.dylib arm64e  <07032fdb352532678ee7ea5c33821bf2> /usr/lib/swift/libswiftUIKit.dylib\n0x1aa502000 - 0x1aa7c7dd3 libicucore.A.dylib arm64e  <743d6e3267613b43ad2f8a9d45cb067a> /usr/lib/libicucore.A.dylib\n0x1aa851000 - 0x1aae28a9f Intents arm64e  <91841049a2a939be85d8eb4c3a0e43ee> /System/Library/Frameworks/Intents.framework/Intents\n0x1aae29000 - 0x1aaf525df CoreSpotlight arm64e  <038d9c394f6f3938b4e81499d425ded6> /System/Library/Frameworks/CoreSpotlight.framework/CoreSpotlight\n0x1aaf53000 - 0x1aaf8c13f Pasteboard arm64e  <49a923338b2e334781df703c656bc898> /System/Library/PrivateFrameworks/Pasteboard.framework/Pasteboard\n0x1aaf8d000 - 0x1ab05ed9f TextInput arm64e  <9b3452b48f41375eb75bd6cad668c750> /System/Library/PrivateFrameworks/TextInput.framework/TextInput\n0x1ab2be000 - 0x1abacd81f AppleMediaServices arm64e  <8bdba75181343d06a45ed299bc3bb355> /System/Library/PrivateFrameworks/AppleMediaServices.framework/AppleMediaServices\n0x1abace000 - 0x1abe6cbcb CoreNavigation arm64e  <07ed43420805304ba017c44d7adbcfe5> /System/Library/PrivateFrameworks/CoreNavigation.framework/CoreNavigation\n0x1abe6d000 - 0x1abef6507 SystemConfiguration arm64e  <d40e499cd89d38339b3ad67d21309d5f> /System/Library/Frameworks/SystemConfiguration.framework/SystemConfiguration\n0x1abef7000 - 0x1ac073a9f CoreUtils arm64e  <cbdabcd0bce73884aabc611d03e07cb3> /System/Library/PrivateFrameworks/CoreUtils.framework/CoreUtils\n0x1ac074000 - 0x1ac0f3fff libswift_Concurrency.dylib arm64e  <7d7ad359d240391b8e01a01153d84033> /usr/lib/swift/libswift_Concurrency.dylib\n0x1ac0f4000 - 0x1ac25677f UIFoundation arm64e  <07dc72b48cd7374d86c6934b01ba4017> /System/Library/PrivateFrameworks/UIFoundation.framework/UIFoundation\n0x1ac257000 - 0x1ac2883ff CoreEmoji arm64e  <614b6cf8ec403b6eb4bf569dd0a694e1> /System/Library/PrivateFrameworks/CoreEmoji.framework/CoreEmoji\n0x1ac289000 - 0x1ac813d1f BiomeStreams arm64e  <327082d3509838f29fc5b1dd7df75880> /System/Library/PrivateFrameworks/BiomeStreams.framework/BiomeStreams\n0x1ac814000 - 0x1ac86439f CoreDuetContext arm64e  <816bc260a659304bbc23c3db86b2ddb0> /System/Library/PrivateFrameworks/CoreDuetContext.framework/CoreDuetContext\n0x1ac865000 - 0x1aca9231f CoreDuet arm64e  <ea1926ecd3b63588984281cbf73ef964> /System/Library/PrivateFrameworks/CoreDuet.framework/CoreDuet\n0x1ad709000 - 0x1ad71b9bf PointerUIServices arm64e  <6d4bd2dad1eb3dcfaa96c926aea6457e> /System/Library/PrivateFrameworks/PointerUIServices.framework/PointerUIServices\n0x1ad71c000 - 0x1ad76187f AppSupport arm64e  <14288933152b35bc885821b06d684b55> /System/Library/PrivateFrameworks/AppSupport.framework/AppSupport\n0x1ad762000 - 0x1ad80d55f SpringBoardServices arm64e  <919187a287db3063b01dbba94833cde8> /System/Library/PrivateFrameworks/SpringBoardServices.framework/SpringBoardServices\n0x1ad80e000 - 0x1ad8c7d7f AXCoreUtilities arm64e  <847c2299bbf33bfe9c7ca5527cb1fa71> /System/Library/PrivateFrameworks/AXCoreUtilities.framework/AXCoreUtilities\n0x1ad8c8000 - 0x1ada5009f CoreMedia arm64e  <903218ad21573e889abdd106dbaf46f1> /System/Library/Frameworks/CoreMedia.framework/CoreMedia\n0x1ada51000 - 0x1addfc33f AudioToolboxCore arm64e  <9c7fa16dfcb631aa8560cdd62b1650a6> /System/Library/PrivateFrameworks/AudioToolboxCore.framework/AudioToolboxCore\n0x1addfd000 - 0x1ade149bf libAudioStatistics.dylib arm64e  <00ea5adb487d35f7be625c5f96f34b6c> /usr/lib/libAudioStatistics.dylib\n0x1ade15000 - 0x1ade4febf libAccessibility.dylib arm64e  <2c3179cc6eee3435a060bb1e6fac2bc8> /usr/lib/libAccessibility.dylib\n0x1ade50000 - 0x1ae26db7f CoreMotion arm64e  <b73a47a293db3101aaecbf4e17ed83bb> /System/Library/Frameworks/CoreMotion.framework/CoreMotion\n0x1ae26e000 - 0x1ae4dd91f CoreLocation arm64e  <67670b77bbef3690aa0f27954d349ced> /System/Library/Frameworks/CoreLocation.framework/CoreLocation\n0x1ae4de000 - 0x1ae5a3c5f ContactsFoundation arm64e  <9ea7c74d1e69312e8bfd70adfe76d444> /System/Library/PrivateFrameworks/ContactsFoundation.framework/ContactsFoundation\n0x1ae5a4000 - 0x1ae7c287f Contacts arm64e  <a36d365cf60f3c33b29d99826144eb31> /System/Library/Frameworks/Contacts.framework/Contacts\n0x1ae7c3000 - 0x1ae7f999f ProactiveEventTracker arm64e  <0db4787ca7bb38c1a00ef0e766bd4198> /System/Library/PrivateFrameworks/ProactiveEventTracker.framework/ProactiveEventTracker\n0x1ae7fa000 - 0x1ae8307bf UserManagement arm64e  <013442dd65e6387aa5a99a2c3c656631> /System/Library/PrivateFrameworks/UserManagement.framework/UserManagement\n0x1ae94f000 - 0x1ae9d705f CalendarFoundation arm64e  <a7db4c8c23fe38e9ba3604040186fe6f> /System/Library/PrivateFrameworks/CalendarFoundation.framework/CalendarFoundation\n0x1af452000 - 0x1af4cb2df IMFoundation arm64e  <1d42b988b12a3dabadd202b45d68d1e0> /System/Library/PrivateFrameworks/IMFoundation.framework/IMFoundation\n0x1af4cc000 - 0x1af6820ff IDS arm64e  <38db25633b7f3569800130162e207e91> /System/Library/PrivateFrameworks/IDS.framework/IDS\n0x1af683000 - 0x1af6b821f UIKitServices arm64e  <d8c8e941c8973b08baa34460a1034db9> /System/Library/PrivateFrameworks/UIKitServices.framework/UIKitServices\n0x1af8c2000 - 0x1afa997ff TeaFoundation arm64e  <bc5d9f51cdff3ec5b5e3013476b1847f> /System/Library/PrivateFrameworks/TeaFoundation.framework/TeaFoundation\n0x1afa9a000 - 0x1afb5667f ExtensionFoundation arm64e  <99c73055abe7351685244f91f084a567> /System/Library/Frameworks/ExtensionFoundation.framework/ExtensionFoundation\n0x1afb57000 - 0x1afbb67bf RunningBoardServices arm64e  <dde2ab2c3d81388e850707030fd4fdc9> /System/Library/PrivateFrameworks/RunningBoardServices.framework/RunningBoardServices\n0x1afbb7000 - 0x1afc4b6ff libTelephonyUtilDynamic.dylib arm64e  <69bd09ef986b394199ff4575abe81584> /usr/lib/libTelephonyUtilDynamic.dylib\n0x1afc4c000 - 0x1b0b089df Espresso arm64e  <db30856fdc093f14b954c3d8de1f1e16> /System/Library/PrivateFrameworks/Espresso.framework/Espresso\n0x1b0bfc000 - 0x1b0d1459f CoreNLP arm64e  <689e9ddb773f33588e69537cd5a905a1> /System/Library/PrivateFrameworks/CoreNLP.framework/CoreNLP\n0x1b0d15000 - 0x1b0d54fef libsystem_malloc.dylib arm64e  <23c37642b23b34a8bd542ac0b5f36047> /usr/lib/system/libsystem_malloc.dylib\n0x1b0d55000 - 0x1b0d6da7f libswiftos.dylib arm64e  <5ea9383eaa24328e81f28923c69a6a32> /usr/lib/swift/libswiftos.dylib\n0x1b0fb3000 - 0x1b0fdcd1f libsystem_info.dylib arm64e  <9aa5d2ab42c63a38ab25af6ce947e7dd> /usr/lib/system/libsystem_info.dylib\n0x1b0fdd000 - 0x1b106cff7 libc++.1.dylib arm64e  <2fbf38d8e5a53ffe9f8736a797ea4cdb> /usr/lib/libc++.1.dylib\n0x1b106d000 - 0x1b11ae5bf AuthKit arm64e  <185a67dd9ba33cc496c5fb3248ddb737> /System/Library/PrivateFrameworks/AuthKit.framework/AuthKit\n0x1b11af000 - 0x1b122b87f TrialProto arm64e  <490bc34f8b22395791f481d83d53dd01> /System/Library/PrivateFrameworks/TrialProto.framework/TrialProto\n0x1b122c000 - 0x1b125557f RTCReporting arm64e  <3efb3881d31c341d88d2ca8a2d9c3c47> /System/Library/PrivateFrameworks/RTCReporting.framework/RTCReporting\n0x1b1256000 - 0x1b162093f CoreImage arm64e  <76fdd773dd013b86923fcda1cc81cea2> /System/Library/Frameworks/CoreImage.framework/CoreImage\n0x1b1621000 - 0x1b1a6581f VideoToolbox arm64e  <543f6c2e483c3af68702d24fe17d8912> /System/Library/Frameworks/VideoToolbox.framework/VideoToolbox\n0x1b1a66000 - 0x1b25bf33f MediaToolbox arm64e  <c84f787e680b35a29579efc783b9fd65> /System/Library/Frameworks/MediaToolbox.framework/MediaToolbox\n0x1b25c0000 - 0x1b2848f1f AVFCore arm64e  <c0729e589a623798a6efc603c77d6119> /System/Library/PrivateFrameworks/AVFCore.framework/AVFCore\n0x1b2849000 - 0x1b2a9bc5f MediaExperience arm64e  <596251590bc235eb831e9aa9c7066941> /System/Library/PrivateFrameworks/MediaExperience.framework/MediaExperience\n0x1b2a9c000 - 0x1b2e52d5f MediaRemote arm64e  <aa4942c6521e3219b0fda3ff2802d47c> /System/Library/PrivateFrameworks/MediaRemote.framework/MediaRemote\n0x1b32e3000 - 0x1b6627cdf WebCore arm64e  <594b96178dce30e2b40e97ce8511ea34> /System/Library/PrivateFrameworks/WebCore.framework/WebCore\n0x1b66e4000 - 0x1b7bedd9f WebKit arm64e  <38f840de4cb93015b3cb931934d315b8> /System/Library/Frameworks/WebKit.framework/WebKit\n0x1b7bee000 - 0x1b950117f JavaScriptCore arm64e  <a8879ed504303775bf58e2e1efcc8ed1> /System/Library/Frameworks/JavaScriptCore.framework/JavaScriptCore\n0x1b9502000 - 0x1b953989f RemoteTextInput arm64e  <a69da4af2c04369fbb6faf932d0e4517> /System/Library/PrivateFrameworks/RemoteTextInput.framework/RemoteTextInput\n0x1b953a000 - 0x1b954e17f UniformTypeIdentifiers arm64e  <566c9cc1034230e7b2b08887fbde5821> /System/Library/Frameworks/UniformTypeIdentifiers.framework/UniformTypeIdentifiers\n0x1b954f000 - 0x1b98e197f Photos arm64e  <09b225f678fa39879ccd22683f87760a> /System/Library/Frameworks/Photos.framework/Photos\n0x1b98e2000 - 0x1ba22d71f PhotoLibraryServices arm64e  <3f166ea8c0743e50951441a4f0bb0433> /System/Library/PrivateFrameworks/PhotoLibraryServices.framework/PhotoLibraryServices\n0x1ba22e000 - 0x1ba34f8ff PhotoLibraryServicesCore arm64e  <eff70aca04a2348c8fdb4583c168135b> /System/Library/PrivateFrameworks/PhotoLibraryServicesCore.framework/PhotoLibraryServicesCore\n0x1ba446000 - 0x1ba4a46ff OnBoardingKit arm64e  <6d526e5b3d343acf8e84313de01a3a1a> /System/Library/PrivateFrameworks/OnBoardingKit.framework/OnBoardingKit\n0x1ba4a5000 - 0x1ba55fb3f AppStoreDaemon arm64e  <d06ca1068b5e31e084e9509532e4b458> /System/Library/PrivateFrameworks/AppStoreDaemon.framework/AppStoreDaemon\n0x1ba9eb000 - 0x1babd717f TelephonyUtilities arm64e  <4c94be794d3c3a18b539320f833b4c78> /System/Library/PrivateFrameworks/TelephonyUtilities.framework/TelephonyUtilities\n0x1babd8000 - 0x1bacab8bf FrontBoardServices arm64e  <1d4f7bf8ca623218a0749187a2d191ae> /System/Library/PrivateFrameworks/FrontBoardServices.framework/FrontBoardServices\n0x1bacac000 - 0x1bad12fff BoardServices arm64e  <6aa038f1a87e33eba560f3476e816207> /System/Library/PrivateFrameworks/BoardServices.framework/BoardServices\n0x1bad13000 - 0x1bad425ff OctagonTrust arm64e  <5019ff70f7df33729a369a19159e6b0a> /System/Library/PrivateFrameworks/OctagonTrust.framework/OctagonTrust\n0x1bad43000 - 0x1bae3ccff CoreParsec arm64e  <09db78e5ac10390bae9bddb49c8aae85> /System/Library/PrivateFrameworks/CoreParsec.framework/CoreParsec\n0x1baf07000 - 0x1bb052aff LinkMetadata arm64e  <e0f8bcf3b8f037e487a7e817efed94b2> /System/Library/PrivateFrameworks/LinkMetadata.framework/LinkMetadata\n0x1bb053000 - 0x1bb0bbb1f DoNotDisturb arm64e  <0789c728854d39c6a79cb92e4d551bd3> /System/Library/PrivateFrameworks/DoNotDisturb.framework/DoNotDisturb\n0x1bb1c3000 - 0x1bb35c47f SiriTTSService arm64e  <8a45d6b6641c365e8920a782d25bc302> /System/Library/PrivateFrameworks/SiriTTSService.framework/SiriTTSService\n0x1bb35d000 - 0x1bb5f3a7f AssistantServices arm64e  <f3619c19f9773de78ef37c46eb1363d9> /System/Library/PrivateFrameworks/AssistantServices.framework/AssistantServices\n0x1bbb70000 - 0x1bbbf6a5f libMobileGestalt.dylib arm64e  <21b225d34a7c3da2ab583eacee682f99> /usr/lib/libMobileGestalt.dylib\n0x1bbbf7000 - 0x1bbd6bfdf AVFAudio arm64e  <c36ff7cee4cb3354b42aa88c397843e4> /System/Library/Frameworks/AVFAudio.framework/AVFAudio\n0x1bbd6c000 - 0x1bbe24d9f Trial arm64e  <2bd2fcbd482e3207b2b7cb3e6508d1af> /System/Library/PrivateFrameworks/Trial.framework/Trial\n0x1bbe25000 - 0x1bc0b9eff IDSFoundation arm64e  <e08655b7767c37bfbc73d223259df28b> /System/Library/PrivateFrameworks/IDSFoundation.framework/IDSFoundation\n0x1bc0ba000 - 0x1bc0e6f3f ApplePushService arm64e  <f72eba6bd70935d69b2373159c215ce7> /System/Library/PrivateFrameworks/ApplePushService.framework/ApplePushService\n0x1bc0e7000 - 0x1bc10215f libsystem_trace.dylib arm64e  <fcb3b2fe7f703793b6e5e96d8cd753fe> /usr/lib/system/libsystem_trace.dylib\n0x1bc103000 - 0x1bc14889f DataDetectorsCore arm64e  <28555edd682c3132b0a56b1173328e42> /System/Library/PrivateFrameworks/DataDetectorsCore.framework/DataDetectorsCore\n0x1bc149000 - 0x1bc1ffd7f AddressBookLegacy arm64e  <310e89f350ed3988a49d0f7fb71be473> /System/Library/PrivateFrameworks/AddressBookLegacy.framework/AddressBookLegacy\n0x1bc200000 - 0x1bc21c107 libsystem_networkextension.dylib arm64e  <5dab30b5969937ebb7dba458ded3267a> /usr/lib/system/libsystem_networkextension.dylib\n0x1bc21d000 - 0x1bc46523f NetworkExtension arm64e  <b771fef366983ff983c713995b51e0ce> /System/Library/Frameworks/NetworkExtension.framework/NetworkExtension\n0x1bc4a9000 - 0x1bc5b3e7f Lexicon arm64e  <33271f072c1f334ea6797374e4058f31> /System/Library/PrivateFrameworks/Lexicon.framework/Lexicon\n0x1bc5b4000 - 0x1bc7c679f Montreal arm64e  <c05038a3f0163c52bde584e76d6a5da2> /System/Library/PrivateFrameworks/Montreal.framework/Montreal\n0x1bc7c7000 - 0x1bc9ce2ff LanguageModeling arm64e  <e1f3a724e20238f9891bf35181b0a590> /System/Library/PrivateFrameworks/LanguageModeling.framework/LanguageModeling\n0x1bc9cf000 - 0x1bd15b5df CoreML arm64e  <c6ad9c8c87c63481861ff3efc3584d57> /System/Library/Frameworks/CoreML.framework/CoreML\n0x1bd15c000 - 0x1bd22d2ff CloudDocs arm64e  <b0a1507a93153c42a164fc84af007211> /System/Library/PrivateFrameworks/CloudDocs.framework/CloudDocs\n0x1bed7b000 - 0x1beeab1ff ShareSheet arm64e  <6172684b07c23dadbd31f6e8b94f1fca> /System/Library/PrivateFrameworks/ShareSheet.framework/ShareSheet\n0x1beeac000 - 0x1bf2d6c7f SearchFoundation arm64e  <9c38dc153f9d38a39a53861b51cb303c> /System/Library/PrivateFrameworks/SearchFoundation.framework/SearchFoundation\n0x1bf2d7000 - 0x1bf33b75f NetworkServiceProxy arm64e  <8c17277d289f3d288486baddfd451fc1> /System/Library/PrivateFrameworks/NetworkServiceProxy.framework/NetworkServiceProxy\n0x1bf3a2000 - 0x1bf42383f LoggingSupport arm64e  <c87bb262cf0f3485a0ef855781561ebf> /System/Library/PrivateFrameworks/LoggingSupport.framework/LoggingSupport\n0x1bf424000 - 0x1bf45ab3f PowerLog arm64e  <04e9316b62ba36d28833b03c695e6deb> /System/Library/PrivateFrameworks/PowerLog.framework/PowerLog\n0x1bf45b000 - 0x1bf57b45f AppleAccount arm64e  <25460c6d2a59308d822786bc94b10847> /System/Library/PrivateFrameworks/AppleAccount.framework/AppleAccount\n0x1bf57c000 - 0x1bf680d5f CoreUI arm64e  <e162b9ed34363e19bf620f1f498f23f2> /System/Library/PrivateFrameworks/CoreUI.framework/CoreUI\n0x1bf681000 - 0x1bf7c05ff ManagedConfiguration arm64e  <81f2effdad093db3a760aa1364d3d3dd> /System/Library/PrivateFrameworks/ManagedConfiguration.framework/ManagedConfiguration\n0x1bf7c1000 - 0x1bf93747f AVFCapture arm64e  <7f33a9451712367a9d91d378a58dcb87> /System/Library/PrivateFrameworks/AVFCapture.framework/AVFCapture\n0x1bf938000 - 0x1bf99771f AudioSession arm64e  <f3cd1fcaeb17326a830fb62e0b851903> /System/Library/PrivateFrameworks/AudioSession.framework/AudioSession\n0x1bf998000 - 0x1bf9a3b5f libGSFont.dylib arm64e  <ce643a6baaa63db7891ebc9303226237> /System/Library/PrivateFrameworks/FontServices.framework/libGSFont.dylib\n0x1c0dc3000 - 0x1c0def6ff BaseBoardUI arm64e  <09f8063266ce3cc8ba68375e7efb39dc> /System/Library/PrivateFrameworks/BaseBoardUI.framework/BaseBoardUI\n0x1c0df0000 - 0x1c0ee3f1f SiriAnalytics arm64e  <2fc9f70da1833b63b850b5e8de00580f> /System/Library/PrivateFrameworks/SiriAnalytics.framework/SiriAnalytics\n0x1c0ee4000 - 0x1c0f341df NearbyInteraction arm64e  <63a2f17fcd7d3a978c90ae979eff457e> /System/Library/Frameworks/NearbyInteraction.framework/NearbyInteraction\n0x1c0f35000 - 0x1c0f5238b TeaSettings arm64e  <c899c370c5da388d9a274277379051ce> /System/Library/PrivateFrameworks/TeaSettings.framework/TeaSettings\n0x1c0f53000 - 0x1c0fb29c8 TeaDB arm64e  <1678052f3bd037ebaea3164f0dfa87a4> /System/Library/PrivateFrameworks/TeaDB.framework/TeaDB\n0x1c1388000 - 0x1c14056df MediaServices arm64e  <33ad0b34ffcf37119ae3dab95528cb4a> /System/Library/PrivateFrameworks/MediaServices.framework/MediaServices\n0x1c1406000 - 0x1c1585a9f PeopleSuggester arm64e  <f0a177db34523a1fb657df508d3aafa3> /System/Library/PrivateFrameworks/PeopleSuggester.framework/PeopleSuggester\n0x1c1586000 - 0x1c16104bf ProactiveSupport arm64e  <d29016a4427f3da0bbea5d32460406ea> /System/Library/PrivateFrameworks/ProactiveSupport.framework/ProactiveSupport\n0x1c1611000 - 0x1c167083f MetadataUtilities arm64e  <1f2131b9a75f3005bc926b1728baacdf> /System/Library/PrivateFrameworks/MetadataUtilities.framework/MetadataUtilities\n0x1c1671000 - 0x1c181f1ff FileProvider arm64e  <18671774ccdf391ea6c6a52cd6da9db7> /System/Library/Frameworks/FileProvider.framework/FileProvider\n0x1c1820000 - 0x1c1839a1f CommonUtilities arm64e  <c3b4919f84d83b4a9af0a8e474efd811> /System/Library/PrivateFrameworks/CommonUtilities.framework/CommonUtilities\n0x1c183a000 - 0x1c18a8edf NanoRegistry arm64e  <364f3f9771ca3a308d69fdd5b6aa21e7> /System/Library/PrivateFrameworks/NanoRegistry.framework/NanoRegistry\n0x1c1bff000 - 0x1c1f3567f AudioToolbox arm64e  <99557863324f3c3eba5f0707cac13bd5> /System/Library/Frameworks/AudioToolbox.framework/AudioToolbox\n0x1c1f36000 - 0x1c24a97df Vision arm64e  <deea1dd789663681b5dfa85625cae431> /System/Library/Frameworks/Vision.framework/Vision\n0x1c24aa000 - 0x1c25c703f PhotosFormats arm64e  <17d5d8a7483b3356997c0e1f6ecb8d2b> /System/Library/PrivateFrameworks/PhotosFormats.framework/PhotosFormats\n0x1c25c8000 - 0x1c26bf53f NLP arm64e  <c2b42791bbbc3224b893a79dc15dd306> /System/Library/PrivateFrameworks/NLP.framework/NLP\n0x1c26c0000 - 0x1c27e857f LinkServices arm64e  <1591a6169f9b3b39b1a79125cad48aeb> /System/Lib",
    "session.id": "AD2E08D1-EB7A-45F9-9140-F08220546170"
  },
  "resource": {
    "attributes": {
      "cloud.region": "us-east-1",
      "service.name": "AwsHackerNewsDemo",
      "geo.region.iso_code": "US-CA",
      "device.model.identifier": "iPhone17,2",
      "os.type": "darwin",
      "aws.rum.appmonitor.name": "AwsRumDemo",
      "device.id": "0664F696-0D18-40D7-9200-476123CB7D03",
      "aws.rum.appmonitor.id": "927baf95-96e9-412b-8126-3c3875669c66",
      "geo.locality.name": "Palo Alto",
      "telemetry.sdk.name": "opentelemetry",
      "os.version": "18.6.2",
      "telemetry.sdk.language": "swift",
      "cloud.provider": "aws",
      "service.version": "1.0 (3)",
      "os.description": "iOS Version 18.6.2 (Build 22G100)",
      "device.model.name": "iPhone 16 Pro Max",
      "os.name": "iOS",
      "rum.sdk.version": "0.0.0",
      "geo.country.iso_code": "US",
      "telemetry.sdk.version": "2.2.0",
      "cloud.platform": "aws_rum"
    }
  },
  "scope": {
    "name": "software.amazon.opentelemetry.KSCrash"
  },
  "timestampUnixNano": 1761722084185000000,
  "observedTimestampUnixNano": 1761722088598585000,
  "eventName": "device.crash"
}
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

