### PR TITLE
feat: add app launch instrumentation

### DIFF
--- a/Sources/AwsOpenTelemetryCore/AppLaunch/AppLaunchProvider.swift
+++ b/Sources/AwsOpenTelemetryCore/AppLaunch/AppLaunchProvider.swift
@@ -1,0 +1,132 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import Foundation
+import Darwin
+
+#if canImport(UIKit) && !os(watchOS)
+  import UIKit
+#endif
+
+public protocol AppLaunchProvider {
+  /// The time when the app launch began
+  var coldLaunchStartTime: Date? { get }
+
+  /// The name of the cold launch start marker. Typically, this occurs before the app is launched so the Notification API cannot help us here
+  var coldStartName: String { get }
+
+  /// The notification that signals when a warm launch begins
+  var warmStartNotification: Notification.Name { get }
+
+  /// The notification that signals when a cold or warm launch has completed
+  var launchEndNotification: Notification.Name { get }
+
+  /// Threshold above which a launch is considered pre-warm
+  var preWarmFallbackThreshold: TimeInterval { get }
+
+  // Notification after which warm launches are allowed to be reported
+  var hiddenNotification: Notification.Name { get }
+
+  /// Additional lifecycle events to record as log events
+  var additionalLifecycleEvents: [Notification.Name] { get }
+}
+
+public class DefaultAppLaunchProvider: AppLaunchProvider {
+  public let coldLaunchStartTime: Date?
+  public let coldStartName: String
+  public let warmStartNotification: Notification.Name
+  public let launchEndNotification: Notification.Name
+  public let hiddenNotification: Notification.Name
+  public let preWarmFallbackThreshold: TimeInterval = 30.0
+  public let additionalLifecycleEvents: [Notification.Name]
+
+  public static let shared = DefaultAppLaunchProvider()
+
+  private init() {
+    coldLaunchStartTime = Self.getProcessStartTime()
+    coldStartName = "kp_proc.p_starttime"
+
+    #if canImport(UIKit) && !os(watchOS)
+      warmStartNotification = UIApplication.willEnterForegroundNotification
+      launchEndNotification = UIApplication.didBecomeActiveNotification
+      hiddenNotification = UIApplication.didEnterBackgroundNotification
+      additionalLifecycleEvents = [
+        UIApplication.didFinishLaunchingNotification,
+        UIApplication.didEnterBackgroundNotification,
+        UIApplication.willResignActiveNotification,
+        UIApplication.willTerminateNotification
+      ]
+    #else
+      // No-op unless UIApplication notifications are available
+      // (generally supported by iOS, iPadOS, Mac Catalyst, tvOS, visionOS)
+      warmStartNotification = Notification.Name("noop.warm")
+      launchEndNotification = Notification.Name("noop.end")
+      hiddenNotification = Notification.Name("noop.hidden")
+      additionalLifecycleEvents = []
+    #endif
+  }
+
+  /// Retrieves the exact timestamp when this process started by querying the kernel.
+  /// I certainly did not come up with this, but you can find many references of its usage in the open source community.
+  static func getProcessStartTime() -> Date? {
+    // Create empty container to hold process information from the kernel
+    var info = kinfo_proc()
+
+    // Tell the system how much space we've allocated for the response
+    var size: Int = MemoryLayout<kinfo_proc>.size
+
+    // Management information base command to lookup process start time
+    var mib: [Int32] = [
+      CTL_KERN, // Instruction to look at kernel information
+      KERN_PROC, // Instruction to look at current processes
+      KERN_PROC_PID, // Instruction to lookup a process ID
+      getpid() // Our current process ID
+    ]
+
+    // Make the actual request to the operating system to fill in info
+    let result = sysctl(
+      &mib, // request_path
+      4, // path_length
+      &info, // response_container
+      &size, // container_size
+      nil, // no_input_data
+      0 // input_size
+    )
+
+    // Check if the system call succeeded (0 = success, anything else = error)
+    guard result == 0 else {
+      AwsOpenTelemetryLogger.error("Failed to get process start time")
+      return nil
+    }
+
+    // The OS has now populated the entire kinfo_proc structure with process data:
+    //   info.kp_proc.p_pid         - Process ID (should match getpid())
+    //   info.kp_proc.p_ppid        - Parent process ID
+    //   info.kp_proc.p_pgrp        - Process group ID
+    //   info.kp_proc.p_uid         - User ID that owns this process
+    //   info.kp_proc.p_gid         - Group ID that owns this process
+    //   info.kp_proc.p_comm        - Process name (executable name)
+    //   info.kp_proc.p_starttime   - When the process started (what we want)
+    //   info.kp_proc.p_stat        - Process state (running, sleeping, etc.)
+    //   info.kp_proc.p_nice        - Process priority/niceness
+    //   info.kp_proc.p_flag        - Various process flags
+    //   info.kp_eproc.e_vm         - Virtual memory info
+
+    // But we are only interesetd in p_starttime to determine cold launch start
+    let startTime = info.kp_proc.p_starttime
+    let timeInterval = TimeInterval(startTime.tv_sec) + TimeInterval(startTime.tv_usec) / 1_000_000
+    return Date(timeIntervalSince1970: timeInterval)
+  }
+}

--- a/Sources/AwsOpenTelemetryCore/AppLaunch/AwsAppLaunchInstrumentation.swift
+++ b/Sources/AwsOpenTelemetryCore/AppLaunch/AwsAppLaunchInstrumentation.swift
@@ -1,0 +1,209 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import Foundation
+import OpenTelemetryApi
+
+#if canImport(UIKit) && !os(watchOS)
+  import UIKit
+#endif
+
+// We want to capture active prewarm flag as early as possible, since it allegedly gets cleared
+// after `UIApplication.didFinishLaunchingNotification`
+let isActivePrewarm: Bool = ProcessInfo.processInfo.environment["ActivePrewarm"] != nil
+
+protocol AppLaunchProtocol {
+  func onWarmStart()
+  func onLaunchEnd()
+  func onLifecycleEvent(name: String)
+  func onHidden()
+}
+
+public class AwsAppLaunchInstrumentation: NSObject, AppLaunchProtocol {
+  static var provider: AppLaunchProvider?
+  private static let lock: NSLock = .init()
+
+  // We need static reference to persist the observers
+  static var shared: AwsAppLaunchInstrumentation?
+
+  // Observer references for cleanup
+  var launchEndObserver: NSObjectProtocol?
+  var warmStartObserver: NSObjectProtocol?
+  var hiddenObserver: NSObjectProtocol?
+  var lifecycleObservers: [String: NSObjectProtocol] = [:]
+
+  static var instrumentationKey: String {
+    return AwsInstrumentationScopes.APP_START
+  }
+
+  static var tracer = OpenTelemetry.instance.tracerProvider.get(instrumentationName: AwsAppLaunchInstrumentation.instrumentationKey)
+  static var logger = OpenTelemetry.instance.loggerProvider.get(instrumentationScopeName: AwsAppLaunchInstrumentation.instrumentationKey)
+
+  // Launch detectors
+  static var hasLaunched = false
+  static var hasLostFocusBefore = false
+  static var lastWarmLaunchStart: Date?
+
+  static func isPrewarm(duration: TimeInterval) -> Bool {
+    guard let provider else { return false }
+    return isActivePrewarm || (provider.preWarmFallbackThreshold > 0 && duration > provider.preWarmFallbackThreshold)
+  }
+
+  public init(provider: AppLaunchProvider = DefaultAppLaunchProvider.shared) {
+    super.init()
+
+    Self.provider = provider
+
+    // Setup launch end handler
+    launchEndObserver = NotificationCenter.default.addObserver(
+      forName: provider.launchEndNotification,
+      object: nil,
+      queue: OperationQueue()
+    ) { _ in
+      Self.onLaunchEnd()
+    }
+
+    // Setup warm launch start handler
+    warmStartObserver = NotificationCenter.default.addObserver(
+      forName: provider.warmStartNotification,
+      object: nil,
+      queue: OperationQueue()
+    ) { _ in
+      Self.onWarmStart()
+    }
+
+    // Setup hidden event handler - only needed until first background event
+    hiddenObserver = NotificationCenter.default.addObserver(
+      forName: provider.hiddenNotification,
+      object: nil,
+      queue: OperationQueue()
+    ) { [weak self] _ in
+      Self.onHidden()
+      // Remove observer after first use since we only need to know app was backgrounded once
+      if let observer = self?.hiddenObserver {
+        NotificationCenter.default.removeObserver(observer)
+        self?.hiddenObserver = nil
+      }
+    }
+
+    // Setup observers
+    for event in provider.additionalLifecycleEvents {
+      guard lifecycleObservers[event.rawValue] == nil else {
+        AwsOpenTelemetryLogger.debug("Skipping duplicate observer for: \(event.rawValue)")
+        continue
+      }
+
+      lifecycleObservers[event.rawValue] = NotificationCenter.default.addObserver(
+        forName: event,
+        object: nil,
+        queue: OperationQueue()
+      ) { notification in
+        Self.onLifecycleEvent(name: notification.name.rawValue)
+      }
+    }
+  }
+
+  func onLaunchEnd() {
+    Self.onLaunchEnd()
+  }
+
+  @objc static func onLaunchEnd() {
+    lock.withLock {
+      guard let provider else { return }
+      let endTime = Date()
+
+      // Handle cold launch
+      if !hasLaunched, let startTime = provider.coldLaunchStartTime {
+        let duration = endTime.timeIntervalSince(startTime)
+        let isPrewarm = isPrewarm(duration: duration)
+
+        tracer.spanBuilder(spanName: "AppStart")
+          .setStartTime(time: startTime)
+          .setAttribute(key: "start.type", value: isPrewarm ? "prewarm" : "cold")
+          .setAttribute(key: "active_prewarm", value: isActivePrewarm)
+          .setAttribute(key: "launch_start_name", value: provider.coldStartName)
+          .setAttribute(key: "launch_end_name", value: provider.launchEndNotification.rawValue)
+          .startSpan()
+          .end(time: endTime)
+        lastWarmLaunchStart = nil // clear stale warm start timestamps
+        hasLaunched = true // only record one cold launch per application lifecycle
+        return
+      }
+
+      // Handle warm launch
+      if hasLostFocusBefore, let startTime = lastWarmLaunchStart {
+        // clear to de-dup future warm launches
+        lastWarmLaunchStart = nil
+
+        // record warm launch
+        tracer.spanBuilder(spanName: "AppStart")
+          .setStartTime(time: startTime)
+          .setAttribute(key: "start.type", value: "warm")
+          .setAttribute(key: "active_prewarm", value: false)
+          .setAttribute(key: "launch_start_name", value: provider.warmStartNotification.rawValue)
+          .setAttribute(key: "launch_end_name", value: provider.launchEndNotification.rawValue)
+          .startSpan()
+          .end(time: endTime)
+      }
+    }
+  }
+
+  func onWarmStart() {
+    Self.onWarmStart()
+  }
+
+  @objc static func onWarmStart() {
+    lock.withLock {
+      let now = Date()
+      lastWarmLaunchStart = now
+    }
+  }
+
+  func onLifecycleEvent(name: String) {
+    Self.onLifecycleEvent(name: name)
+  }
+
+  @objc static func onLifecycleEvent(name: String) {
+    logger.logRecordBuilder()
+      .setEventName(name)
+      .emit()
+  }
+
+  func onHidden() {
+    Self.onHidden()
+  }
+
+  @objc static func onHidden() {
+    lock.withLock {
+      hasLostFocusBefore = true
+    }
+  }
+
+  deinit {
+    // Clean up all observers
+    if let observer = launchEndObserver {
+      NotificationCenter.default.removeObserver(observer)
+    }
+    if let observer = warmStartObserver {
+      NotificationCenter.default.removeObserver(observer)
+    }
+    if let observer = hiddenObserver {
+      NotificationCenter.default.removeObserver(observer)
+    }
+    for observer in lifecycleObservers.values {
+      NotificationCenter.default.removeObserver(observer)
+    }
+  }
+}

--- a/Sources/AwsOpenTelemetryCore/AppLaunch/README.md
+++ b/Sources/AwsOpenTelemetryCore/AppLaunch/README.md
@@ -1,0 +1,122 @@
+# App Launch Instrumentation
+
+The App Launch instrumentation module provides automatic tracking of iOS application launch performance by creating OpenTelemetry spans that measure cold and warm launch times, including pre-warm launch detection.
+
+## Overview
+
+This instrumentation captures different types of app launches:
+
+- **Cold Launch**: App starts from scratch (process creation to launch completion)
+- **Warm Launch**: App returns from background to foreground
+- **Pre-warm Launch**: A cold launch that was pre-warmed by the OS, either explicitly with the active-prewarm flag or implicitly if app launch time exceeds a threshold (default 30 seconds)
+
+## Components
+
+### AppLaunchProvider
+
+A protocol that defines the interface for providing app launch timing data:
+
+```swift
+public protocol AppLaunchProvider {
+  var coldLaunchStartTime: Date { get }
+  var coldEndNotification: Notification.Name { get }
+  var warmStartNotification: Notification.Name { get }
+  var warmEndNotification: Notification.Name { get }
+  var preWarmFallbackThreshold: TimeInterval { get }
+}
+```
+
+#### AppLaunchProvider Parameters
+
+| Parameter                  | Type                | Description                                                                                                                            | Default (DefaultAppLaunchProvider)              |
+| -------------------------- | ------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| `coldLaunchStartTime`      | `Date`              | The time when the app process started                                                                                                  | Process start time from `kinfo_proc`            |
+| `warmStartNotification`    | `Notification.Name` | Notification fired when warm launch begins                                                                                             | `UIApplication.willEnterForegroundNotification` |
+| `launchEnd`                | `Notification.Name` | Notification fired when a launch completes                                                                                             | `UIApplication.didBecomeActiveNotification`     |
+| `preWarmFallbackThreshold` | `TimeInterval`      | Duration threshold (seconds) above which launches are classified as pre-warm. Set to `0` to disable threshold-based fallback detection | `30.0`                                          |
+
+### DefaultAppLaunchProvider
+
+The default implementation that:
+
+- Calculates process start time using `kinfo_proc` system call for accurate cold launch timing
+- Uses `UIApplication.willEnterForegroundNotification` for warm launch start
+- Uses `UIApplication.didBecomeActiveNotification` for all launch completions
+- Sets pre-warm threshold to 30 seconds by default
+- Only available on UIKit platforms (iOS, tvOS, macOS with UIKit)
+
+### AwsAppLaunchInstrumentation
+
+The main instrumentation class that:
+
+- Creates `AppStart` spans for both cold and warm launches
+- Detects pre-warm launches using duration thresholds or `ActivePrewarm` environment variable
+- Ensures only one cold launch is recorded per app session
+- Tracks warm launch start times automatically after the first hidden event fires
+- Uses thread-safe static state management
+
+## Launch Type Detection
+
+### Cold Launch
+
+- Triggered by the first `launchEndNotification`
+- Measures from process start to launch completion
+- Automatically classified as `PRE_WARM` if duration exceeds threshold or `ActivePrewarm` flag was detected
+
+### Warm Launch
+
+- Only recorded after a hidden event fires to avoid writing warm launch for the initial launch
+- Triggered by `warmStartNotification` and `launchEndNotification`
+- Measures from foreground entry to active state
+
+### Pre-warm Detection
+
+- Uses `ActivePrewarm` environment variable if present
+- Falls back to duration-based detection using `preWarmFallbackThreshold`
+- Threshold of 0 disables fallback detection
+
+## Usage
+
+The instrumentation is automatically enabled when the `startup` telemetry feature is enabled:
+
+```json
+{
+  "telemetry": {
+    "startup": { "enabled": true }
+  }
+}
+```
+
+Or programmatically:
+
+```swift
+let config = AwsTelemetryConfig()
+  .withStartup(enabled: true)
+```
+
+## Custom Implementation
+
+You can provide a custom provider:
+
+```swift
+let customProvider = MyAppLaunchProvider()
+let instrumentation = AwsAppLaunchInstrumentation(provider: customProvider)
+```
+
+## Platform Behavior
+
+- **iOS/tvOS/macOS with UIKit**: Full functionality with default notifications
+- **watchOS or non-UIKit platforms**: Requires custom provider implementation
+
+## Generated Telemetry
+
+The instrumentation creates spans with:
+
+- **Name**: `AppStart`
+- **Attributes**:
+  - `launch.type`: `COLD`, `WARM`, or `PRE_WARM`
+  - `launch_start_name`: Name of the start notification
+  - `launch_end_name`: Name of the end notification
+  - `active_prewarm`: Boolean indicating if `ActivePrewarm` environment variable is set
+- **Instrumentation Scope**: `software.amazon.opentelemetry.AppStart`
+- **Timing**: Accurate start/end times based on actual system events

--- a/Sources/AwsOpenTelemetryCore/AwsOpenTelemetryRumBuilder.swift
+++ b/Sources/AwsOpenTelemetryCore/AwsOpenTelemetryRumBuilder.swift
@@ -172,6 +172,12 @@ public class AwsOpenTelemetryRumBuilder {
 
   /// Execute AwsInstrumentationPlan to build requested instrumentations
   private func buildInstrumentations(plan: AwsInstrumentationPlan) {
+    // App Launch
+    if plan.startup {
+      // Only supported by default for environments that support UIKit lifecycle notifications
+      AwsAppLaunchInstrumentation.shared = AwsAppLaunchInstrumentation()
+    }
+
     // Session Events
     if plan.sessionEvents {
       _ = AwsSessionEventInstrumentation()

--- a/Sources/AwsOpenTelemetryCore/Constants/AwsInstrumentationScopes.swift
+++ b/Sources/AwsOpenTelemetryCore/Constants/AwsInstrumentationScopes.swift
@@ -19,8 +19,13 @@ import Foundation
 public enum AwsInstrumentationScopes {
   public static let CRASH_DIAGNOSTIC = "software.amazon.opentelemetry.MXCrashDiagnostic"
   public static let HANG_DIAGNOSTIC = "software.amazon.opentelemetry.MXHangDiagnostic"
-  public static let APP_LAUNCH_DIAGNOSTIC = "software.amazon.opentelemetry.MXAppLaunchDiagnostic"
+  public static let APP_LAUNCH_DIAGNOSTIC = "software.amazon.opentelemetry.MXAppLaunchDiagnostic" // keeping this temporarily before we fully deprecate metric kit app launches
+  public static let APP_START = "software.amazon.opentelemetry.AppStart"
   public static let SESSION = "software.amazon.opentelemetry.session"
   public static let UIKIT_VIEW = "software.amazon.opentelemetry.UIKitView"
   public static let SWIFTUI_VIEW = "software.amazon.opentelemetry.SwiftUIView"
+  public static let HANG = "software.amazon.opentelemetry.Hang"
+  public static let PING_HANG_REPORTER = "software.amazon.opentelemetry.PingHangReporter"
+  public static let RUNLOOP_HANG_REPORTER = "software.amazon.opentelemetry.RunLoopHangReporter"
+  public static let KSCRASH = "software.amazon.opentelemetry.KSCrash"
 }

--- a/Tests/AwsOpenTelemetryCoreTests/AppLaunch/AppLaunchInstrumentationTests.swift
+++ b/Tests/AwsOpenTelemetryCoreTests/AppLaunch/AppLaunchInstrumentationTests.swift
@@ -1,0 +1,316 @@
+import XCTest
+@testable import AwsOpenTelemetryCore
+import OpenTelemetryApi
+import OpenTelemetrySdk
+
+class MockAppLaunchProvider: AppLaunchProvider {
+  var coldLaunchStartTime: Date?
+  var coldStartName: String = "mock.cold.start"
+  var warmStartNotification: Notification.Name = .init("mock.warm.start")
+  var launchEndNotification: Notification.Name = .init("mock.launch.end")
+  var preWarmFallbackThreshold: TimeInterval = 30.0
+  var hiddenNotification: Notification.Name = .init("mock.hidden")
+  var additionalLifecycleEvents: [Notification.Name] = []
+
+  init() {
+    // Provide a default cold launch start time
+    coldLaunchStartTime = Date().addingTimeInterval(-1.0)
+  }
+}
+
+class MockSpanExporter: SpanExporter {
+  var exportedSpans: [SpanData] = []
+
+  func export(spans: [SpanData], explicitTimeout: TimeInterval?) -> SpanExporterResultCode {
+    exportedSpans.append(contentsOf: spans)
+    return .success
+  }
+
+  func flush(explicitTimeout: TimeInterval?) -> SpanExporterResultCode {
+    return .success
+  }
+
+  func shutdown(explicitTimeout: TimeInterval?) {}
+}
+
+class MockLogExporter: LogRecordExporter {
+  var exportedLogs: [ReadableLogRecord] = []
+
+  func export(logRecords: [ReadableLogRecord], explicitTimeout: TimeInterval?) -> ExportResult {
+    exportedLogs.append(contentsOf: logRecords)
+    return .success
+  }
+
+  func shutdown(explicitTimeout: TimeInterval?) {}
+
+  func forceFlush(explicitTimeout: TimeInterval?) -> ExportResult {
+    return .success
+  }
+}
+
+final class AwsAppLaunchInstrumentationTests: XCTestCase {
+  var mockProvider: MockAppLaunchProvider!
+  var instrumentation: AwsAppLaunchInstrumentation!
+  var spanExporter: MockSpanExporter!
+  var logExporter: MockLogExporter!
+  var tracerProvider: TracerProviderSdk!
+  var loggerProvider: LoggerProviderSdk!
+
+  override func setUp() {
+    super.setUp()
+    mockProvider = MockAppLaunchProvider()
+
+    // Set up mock exporters
+    spanExporter = MockSpanExporter()
+    logExporter = MockLogExporter()
+
+    // Create providers with mock exporters
+    tracerProvider = TracerProviderBuilder()
+      .add(spanProcessor: BatchSpanProcessor(spanExporter: spanExporter))
+      .build()
+
+    loggerProvider = LoggerProviderSdk(
+      logRecordProcessors: [SimpleLogRecordProcessor(logRecordExporter: logExporter)]
+    )
+
+    // Reset static state manually
+    AwsAppLaunchInstrumentation.hasLaunched = false
+    AwsAppLaunchInstrumentation.hasLostFocusBefore = false
+    AwsAppLaunchInstrumentation.lastWarmLaunchStart = nil
+    AwsAppLaunchInstrumentation.provider = nil
+    AwsAppLaunchInstrumentation.tracer = tracerProvider.get(instrumentationName: "test")
+    AwsAppLaunchInstrumentation.logger = loggerProvider.get(instrumentationScopeName: "test")
+  }
+
+  override func tearDown() {
+    instrumentation = nil
+    mockProvider = nil
+    spanExporter = nil
+    logExporter = nil
+    tracerProvider = nil
+    loggerProvider = nil
+    super.tearDown()
+  }
+
+  func testColdLaunchRecording() {
+    // Given
+    let startTime = Date().addingTimeInterval(-2.0)
+    mockProvider.coldLaunchStartTime = startTime
+    mockProvider.coldStartName = "test.cold.start"
+
+    instrumentation = AwsAppLaunchInstrumentation(provider: mockProvider)
+
+    // When
+    instrumentation.onLaunchEnd()
+
+    // Force flush to ensure spans are exported
+    tracerProvider.forceFlush()
+
+    // Then
+    XCTAssertEqual(spanExporter.exportedSpans.count, 1)
+    let span = spanExporter.exportedSpans.first!
+    XCTAssertEqual(span.name, "AppStart")
+    XCTAssertEqual(span.startTime, startTime)
+    XCTAssertEqual(span.attributes["start.type"]?.description, "cold")
+    XCTAssertEqual(span.attributes["launch_start_name"]?.description, "test.cold.start")
+  }
+
+  func testPrewarmLaunchDetection() {
+    // Given - Long duration should trigger prewarm detection
+    let startTime = Date().addingTimeInterval(-35.0) // 35 seconds ago
+    mockProvider.coldLaunchStartTime = startTime
+    mockProvider.preWarmFallbackThreshold = 30.0
+
+    instrumentation = AwsAppLaunchInstrumentation(provider: mockProvider)
+
+    // When
+    instrumentation.onLaunchEnd()
+
+    // Force flush to ensure spans are exported
+    tracerProvider.forceFlush()
+
+    // Then
+    XCTAssertEqual(spanExporter.exportedSpans.count, 1)
+    let span = spanExporter.exportedSpans.first!
+    XCTAssertEqual(span.attributes["start.type"]?.description, "prewarm")
+  }
+
+  func testWarmLaunchRecording() {
+    // Given - No cold launch start time to avoid cold launch
+    mockProvider.coldLaunchStartTime = nil
+    instrumentation = AwsAppLaunchInstrumentation(provider: mockProvider)
+    instrumentation.onHidden() // Mark as having lost focus
+
+    // When - Warm start followed by launch end
+    instrumentation.onWarmStart()
+    Thread.sleep(forTimeInterval: 0.1) // Small delay
+    instrumentation.onLaunchEnd()
+
+    // Force flush to ensure spans are exported
+    tracerProvider.forceFlush()
+
+    // Then
+    XCTAssertEqual(spanExporter.exportedSpans.count, 1)
+    let span = spanExporter.exportedSpans.first!
+    XCTAssertEqual(span.name, "AppStart")
+    XCTAssertEqual(span.attributes["start.type"]?.description, "warm")
+    XCTAssertEqual(span.attributes["active_prewarm"]?.description, "false")
+  }
+
+  func testNoLaunchWhenConditionsNotMet() {
+    mockProvider.coldLaunchStartTime = nil
+    instrumentation = AwsAppLaunchInstrumentation(provider: mockProvider)
+
+    // Test no cold launch when start time unavailable
+    instrumentation.onLaunchEnd()
+    XCTAssertEqual(spanExporter.exportedSpans.count, 0)
+
+    // Test no warm launch without prior hidden
+    instrumentation.onWarmStart()
+    instrumentation.onLaunchEnd()
+    tracerProvider.forceFlush()
+    XCTAssertEqual(spanExporter.exportedSpans.count, 0)
+  }
+
+  func testLifecycleEventLogging() {
+    // Given
+    instrumentation = AwsAppLaunchInstrumentation(provider: mockProvider)
+
+    // When
+    instrumentation.onLifecycleEvent(name: "test.lifecycle.event")
+
+    // Then
+    XCTAssertEqual(logExporter.exportedLogs.count, 1)
+    let logRecord = logExporter.exportedLogs.first!
+    XCTAssertEqual(logRecord.eventName, "test.lifecycle.event")
+  }
+
+  func testOnlyOneColdLaunchPerLifecycle() {
+    // Given
+    let startTime = Date().addingTimeInterval(-1.0)
+    mockProvider.coldLaunchStartTime = startTime
+    instrumentation = AwsAppLaunchInstrumentation(provider: mockProvider)
+
+    // When - Multiple launch end calls
+    instrumentation.onLaunchEnd()
+    instrumentation.onLaunchEnd()
+
+    // Force flush to ensure spans are exported
+    tracerProvider.forceFlush()
+
+    // Then - Only one span recorded
+    XCTAssertEqual(spanExporter.exportedSpans.count, 1)
+  }
+
+  func testWarmLaunchClearsAfterRecording() {
+    // Given - No cold launch start time to avoid cold launch
+    mockProvider.coldLaunchStartTime = nil
+    instrumentation = AwsAppLaunchInstrumentation(provider: mockProvider)
+    instrumentation.onHidden()
+    instrumentation.onWarmStart()
+
+    // When - First launch end
+    instrumentation.onLaunchEnd()
+    // Second launch end without new warm start
+    instrumentation.onLaunchEnd()
+
+    // Force flush to ensure spans are exported
+    tracerProvider.forceFlush()
+
+    // Then - Only one warm launch recorded
+    XCTAssertEqual(spanExporter.exportedSpans.count, 1)
+  }
+
+  func testIsPrewarmDetection() {
+    mockProvider.preWarmFallbackThreshold = 30.0
+    AwsAppLaunchInstrumentation.provider = mockProvider
+
+    XCTAssertFalse(AwsAppLaunchInstrumentation.isPrewarm(duration: 2.0))
+    XCTAssertTrue(AwsAppLaunchInstrumentation.isPrewarm(duration: 35.0))
+
+    // Test edge cases
+    AwsAppLaunchInstrumentation.provider = nil
+    XCTAssertFalse(AwsAppLaunchInstrumentation.isPrewarm(duration: 35.0))
+
+    mockProvider.preWarmFallbackThreshold = 0
+    AwsAppLaunchInstrumentation.provider = mockProvider
+    XCTAssertFalse(AwsAppLaunchInstrumentation.isPrewarm(duration: 35.0))
+  }
+
+  func testInstrumentationSetup() {
+    XCTAssertEqual(AwsAppLaunchInstrumentation.instrumentationKey, AwsInstrumentationScopes.APP_START)
+
+    instrumentation = AwsAppLaunchInstrumentation(provider: mockProvider)
+    XCTAssertNotNil(instrumentation.launchEndObserver)
+    XCTAssertNotNil(instrumentation.warmStartObserver)
+    XCTAssertNotNil(instrumentation.hiddenObserver)
+  }
+
+  func testLifecycleObserverSetup() {
+    mockProvider.additionalLifecycleEvents = [
+      Notification.Name("test.event1"),
+      Notification.Name("test.event2")
+    ]
+
+    instrumentation = AwsAppLaunchInstrumentation(provider: mockProvider)
+
+    XCTAssertEqual(instrumentation.lifecycleObservers.count, 2)
+    XCTAssertNotNil(instrumentation.lifecycleObservers["test.event1"])
+    XCTAssertNotNil(instrumentation.lifecycleObservers["test.event2"])
+  }
+
+  func testDuplicateLifecycleObserverSkipped() {
+    let duplicateEvent = Notification.Name("duplicate.event")
+    mockProvider.additionalLifecycleEvents = [duplicateEvent, duplicateEvent]
+
+    instrumentation = AwsAppLaunchInstrumentation(provider: mockProvider)
+
+    XCTAssertEqual(instrumentation.lifecycleObservers.count, 1)
+  }
+
+  func testHiddenObserverRemovedAfterFirstUse() {
+    instrumentation = AwsAppLaunchInstrumentation(provider: mockProvider)
+
+    XCTAssertNotNil(instrumentation.hiddenObserver)
+
+    // Post the actual notification to trigger the observer removal
+    NotificationCenter.default.post(name: mockProvider.hiddenNotification, object: nil)
+
+    // Give the notification time to process
+    RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+
+    XCTAssertNil(instrumentation.hiddenObserver)
+  }
+
+  func testStaticMethods() {
+    // Test with valid provider
+    AwsAppLaunchInstrumentation.provider = mockProvider
+    AwsAppLaunchInstrumentation.onLifecycleEvent(name: "static.test")
+    XCTAssertEqual(logExporter.exportedLogs.count, 1)
+
+    // Test with nil provider
+    AwsAppLaunchInstrumentation.provider = nil
+    XCTAssertNoThrow(AwsAppLaunchInstrumentation.onLaunchEnd())
+    XCTAssertNoThrow(AwsAppLaunchInstrumentation.onWarmStart())
+    XCTAssertNoThrow(AwsAppLaunchInstrumentation.onHidden())
+  }
+
+  func testLaunchDeduplication() {
+    // Test cold launch only recorded once
+    mockProvider.coldLaunchStartTime = Date().addingTimeInterval(-1.0)
+    instrumentation = AwsAppLaunchInstrumentation(provider: mockProvider)
+
+    instrumentation.onLaunchEnd()
+    instrumentation.onLaunchEnd()
+    tracerProvider.forceFlush()
+    XCTAssertEqual(spanExporter.exportedSpans.count, 1)
+
+    // Test warm launch without warm start
+    mockProvider.coldLaunchStartTime = nil
+    instrumentation = AwsAppLaunchInstrumentation(provider: mockProvider)
+    instrumentation.onHidden()
+    instrumentation.onLaunchEnd()
+    tracerProvider.forceFlush()
+    XCTAssertEqual(spanExporter.exportedSpans.count, 1) // Still only 1 from cold launch
+  }
+}

--- a/Tests/AwsOpenTelemetryCoreTests/AppLaunch/AppLaunchProviderTests.swift
+++ b/Tests/AwsOpenTelemetryCoreTests/AppLaunch/AppLaunchProviderTests.swift
@@ -1,0 +1,124 @@
+import XCTest
+@testable import AwsOpenTelemetryCore
+
+#if canImport(UIKit) && !os(watchOS)
+  import UIKit
+
+  final class DefaultAppLaunchProviderUIKitTests: XCTestCase {
+    func testColdLaunchStartTime() {
+      let provider = DefaultAppLaunchProvider.shared
+
+      XCTAssertNotNil(provider.coldLaunchStartTime, "Cold launch start time should not be nil")
+      XCTAssertTrue(provider.coldLaunchStartTime! <= Date(), "Cold launch start time should be in the past")
+    }
+
+    func testGetProcessStartTimeErrorHandling() {
+      let startTime = DefaultAppLaunchProvider.getProcessStartTime()
+      XCTAssertNotNil(startTime)
+    }
+
+    func testColdStartName() {
+      let provider = DefaultAppLaunchProvider.shared
+
+      XCTAssertEqual(provider.coldStartName, "kp_proc.p_starttime")
+    }
+
+    func testNotificationNames() {
+      let provider = DefaultAppLaunchProvider.shared
+      XCTAssertEqual(provider.warmStartNotification, UIApplication.willEnterForegroundNotification)
+      XCTAssertEqual(provider.launchEndNotification, UIApplication.didBecomeActiveNotification)
+      XCTAssertEqual(provider.hiddenNotification, UIApplication.didEnterBackgroundNotification)
+    }
+
+    func testPreWarmFallbackThreshold() {
+      let provider = DefaultAppLaunchProvider.shared
+      XCTAssertEqual(provider.preWarmFallbackThreshold, 30.0)
+    }
+
+    func testAdditionalLifecycleEvents() {
+      let provider = DefaultAppLaunchProvider.shared
+      let expectedEvents: [Notification.Name] = [
+        UIApplication.didFinishLaunchingNotification,
+        UIApplication.didEnterBackgroundNotification,
+        UIApplication.willResignActiveNotification,
+        UIApplication.willTerminateNotification
+      ]
+
+      XCTAssertEqual(provider.additionalLifecycleEvents.count, expectedEvents.count)
+      for event in expectedEvents {
+        XCTAssertTrue(provider.additionalLifecycleEvents.contains(event))
+      }
+    }
+
+    func testGetProcessStartTime() {
+      let startTime = DefaultAppLaunchProvider.getProcessStartTime()
+
+      XCTAssertNotNil(startTime, "Process start time should not be nil")
+      XCTAssertTrue(startTime! <= Date(), "Process start time should be in the past")
+
+      // Process should have started within reasonable time (e.g., last hour)
+      let oneHourAgo = Date().addingTimeInterval(-3600)
+      XCTAssertTrue(startTime! >= oneHourAgo, "Process start time should be recent")
+    }
+
+    func testProcessStartTimeConsistency() {
+      let time1 = DefaultAppLaunchProvider.getProcessStartTime()
+      let time2 = DefaultAppLaunchProvider.getProcessStartTime()
+
+      XCTAssertNotNil(time1)
+      XCTAssertNotNil(time2)
+
+      // Should return the same time (within small tolerance for execution time)
+      let timeDifference = abs(time1!.timeIntervalSince(time2!))
+      XCTAssertLessThan(timeDifference, 0.001, "Process start time should be consistent")
+    }
+
+    func testSharedInstanceConsistency() {
+      let provider1 = DefaultAppLaunchProvider.shared
+      let provider2 = DefaultAppLaunchProvider.shared
+
+      XCTAssertTrue(provider1 === provider2, "Shared instance should be the same object")
+    }
+  }
+
+#else
+
+  final class DefaultAppLaunchProviderNonUIKitTests: XCTestCase {
+    func testNonUIKitPlatformBehavior() {
+      let provider = DefaultAppLaunchProvider.shared
+
+      // Process start time should still work on non-UIKit platforms
+      XCTAssertNotNil(provider.coldLaunchStartTime, "Cold launch start time should not be nil")
+      XCTAssertTrue(provider.coldLaunchStartTime! <= Date(), "Cold launch start time should be in the past")
+
+      // Cold start name should be consistent
+      XCTAssertEqual(provider.coldStartName, "kp_proc.p_starttime")
+
+      // No-op notifications should be used
+      XCTAssertEqual(provider.warmStartNotification, Notification.Name("noop.warm"))
+      XCTAssertEqual(provider.launchEndNotification, Notification.Name("noop.end"))
+      XCTAssertEqual(provider.hiddenNotification, Notification.Name("noop.hidden"))
+
+      // No additional lifecycle events on non-UIKit platforms
+      XCTAssertTrue(provider.additionalLifecycleEvents.isEmpty)
+
+      // Threshold should still be set
+      XCTAssertEqual(provider.preWarmFallbackThreshold, 30.0)
+    }
+
+    func testGetProcessStartTimeOnNonUIKitPlatforms() {
+      let startTime = DefaultAppLaunchProvider.getProcessStartTime()
+
+      XCTAssertNotNil(startTime, "Process start time should not be nil")
+      XCTAssertTrue(startTime! <= Date(), "Process start time should be in the past")
+    }
+
+    func testSharedInstanceConsistency() {
+      let provider1 = DefaultAppLaunchProvider.shared
+      let provider2 = DefaultAppLaunchProvider.shared
+
+      XCTAssertTrue(provider1 === provider2, "Shared instance should be the same object")
+    }
+  }
+
+#endif


### PR DESCRIPTION
## Summary

MXAppLaunchDiagnostic is not useful for us because it is not real-time or guaranteed to be reported. If anything should be sent to the Metrics API when that becomes available. We are disabling metric kit except for crashes for all real-time event monitoring in another PR. Instead, we need manual instrumentation.


## Implementation

We use notification-based tracking for launch activities. 

1. Cold launch start - we use a system level command to get the start time of the process that is running the application. Admittedly, this looks a little sketchy, but there are many references of this particular command across the open source community. 
2. Prewarm detection - the initial cold launch can also be prewarmed, which we will have positive confirmation of when the ActivePrewarm environmental variable is supplied. According to Sentry, this flag is cleared after the `didFinishLaunching` notification is fired so we need to evaluate this immediately via global variable (https://github.com/getsentry/sentry-cocoa/blob/e648312d3599e0c5331540d6c210acdb087d705d/Sources/Sentry/SentryAppStartTracker.m#L44-L49). In addition, if by the off chance that we cannot capture this via ActivePrewarm flag, then I have set a prewarm fallback detection threshold of 30 seconds. 
4. Warm launch start - we use the notification for when the app is about to be loaded into the foreground, which is a great lightweight approximation for when the application is about to resume work on the main thread. There are more precise ways to do this, but I this is definitely good enough for our purposes. As a safety check, I only allow reporting warm launches after the app was hidden at least once. 
5. Launch end is the same across all launch types (warm, prewarm, cold), which is the `didBecomeActive` notification. This seems to be the most relevant since that is when the application is actually to start receiving interactions from the end user. But it is likely that application owners will want to reconfigure this to a specific view completion. 

Additional lifecycle events - I also added logging for other important events that are relevant to the application lifecycle. 

1. didFinishLaunching
2. didEnterBackgroundNotification
3. willResignActiveNotification
4. willTerminateNotification

Notably, these are not included since they are already captured by the launch spans
1. willEnterForegroundNotification
2. didBecomeActiveNotification

## Testing

Tested extensively against AwsHackerNewsDemo app across various devices and beta users.

<img width="1361" height="1695" alt="Screenshot 2025-10-29 at 7 49 01 AM" src="https://github.com/user-attachments/assets/768fb994-4d8b-4a84-bc29-41a9a4fc18ef" />

```jsonc
// cold launch
{
  "type": "span",
  "traceId": "DwV12H1VenuOkZvfabmypg==",
  "spanId": "tyBPa1RG5Qc=",
  "name": "AppStart",
  "kind": "SPAN_KIND_INTERNAL",
  "startTimeUnixNano": "1761749224956985856",
  "endTimeUnixNano": "1761749227360409088",
  "attributes": [
    {
      "key": "active_prewarm",
      "value": {
        "boolValue": false
      }
    },
    {
      "key": "start.type",
      "value": {
        "stringValue": "cold"
      }
    },
    {
      "key": "session.id",
      "value": {
        "stringValue": "9E74AE59-5E08-4FF7-B4C1-B18EF5DD00FF"
      }
    },
    {
      "key": "launch_start_name",
      "value": {
        "stringValue": "kp_proc.p_starttime"
      }
    },
    {
      "key": "session.previous_id",
      "value": {
        "stringValue": "6C3DF1A0-76B9-495E-A18D-A6A98498192E"
      }
    },
    {
      "key": "user.id",
      "value": {
        "stringValue": "D69A6271-24FA-42AA-A68D-FD90DB5D2190"
      }
    },
    {
      "key": "launch_end_name",
      "value": {
        "stringValue": "UIApplicationDidBecomeActiveNotification"
      }
    }
  ],
  "status": {},
  "timestamp": 1761749224956.9858,
  "endTime": 1761749227360.4092,
  "scopeName": "software.amazon.opentelemetry.AppStart",
  "duration": 2403.423232
}
```

```jsonc
// warm launch
{
  "type": "span",
  "traceId": "so9YnFKuac/GawdW5Sakgg==",
  "spanId": "SB9gUkJWTeg=",
  "name": "AppStart",
  "kind": "SPAN_KIND_INTERNAL",
  "startTimeUnixNano": "1761749232579036928",
  "endTimeUnixNano": "1761749232885593856",
  "attributes": [
    {
      "key": "session.previous_id",
      "value": {
        "stringValue": "6C3DF1A0-76B9-495E-A18D-A6A98498192E"
      }
    },
    {
      "key": "session.id",
      "value": {
        "stringValue": "9E74AE59-5E08-4FF7-B4C1-B18EF5DD00FF"
      }
    },
    {
      "key": "user.id",
      "value": {
        "stringValue": "D69A6271-24FA-42AA-A68D-FD90DB5D2190"
      }
    },
    {
      "key": "active_prewarm",
      "value": {
        "boolValue": false
      }
    },
    {
      "key": "launch_end_name",
      "value": {
        "stringValue": "UIApplicationDidBecomeActiveNotification"
      }
    },
    {
      "key": "launch_start_name",
      "value": {
        "stringValue": "UIApplicationWillEnterForegroundNotification"
      }
    },
    {
      "key": "start.type",
      "value": {
        "stringValue": "warm"
      }
    }
  ],
  "status": {},
  "timestamp": 1761749232579.0369,
  "endTime": 1761749232885.5938,
  "scopeName": "software.amazon.opentelemetry.AppStart",
  "duration": 306.556928
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

