### PR TITLE
chore(release): v0.0.0

### DIFF
--- a/.github/workflows/PreRelease.yml
+++ b/.github/workflows/PreRelease.yml
@@ -72,7 +72,7 @@ jobs:
               echo "Branch release/v${MAJOR_MINOR}.x already exists, checking out."
               git checkout "release/v${MAJOR_MINOR}.x"
             else 
-              echo "Error, release series branch release/v${MAJOR_MINOR}.x exist for non-patch release"
+              echo "Error, release series branch release/v${MAJOR_MINOR}.x exists for non-patch release"
               echo "Check your input or branch"
               exit 1
             fi

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -21,9 +21,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         # GITHUB_REF_NAME is a GitHub Actions environment variable that contains the short ref name of the branch or tag that triggered the workflow run.
+        # SPM officially recognizes tags both with and without this prefix. 1.0.0 is the recommended and standard way to tag a release for Swift packages.
         run: |
           gh release create --target "$GITHUB_REF_NAME" \ 
-             --title "Release v${VERSION}" \
+             --title "Release ${VERSION}" \
              --draft \
-             "v${VERSION}" \
+             "${VERSION}" \
              .

--- a/Info.plist
+++ b/Info.plist
@@ -1,3 +1,3 @@
 {
-	"CFBundleShortVersionString" = "1.0.0";
+	"CFBundleShortVersionString" = "0.0.0";
 }


### PR DESCRIPTION
# Release `0.0.0`

Creating a test release to exercise release workflows. 


## Testing

Tested PreRelease.yml workflow at https://github.com/aws-observability/aws-otel-swift/actions/runs/19251596460/job/55037543328.

It only failed because main has version 1.0.0. this change updates that to 0.0.0 and preps the branch for Release.yml to tag a release.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

