### PR TITLE
fix(release): update gh release command to use v prefix while tagging a release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 # Changelog
 
-<<<<<<< HEAD
 All notable changes to this project will be documented in this file.
 
 > **Note:** This CHANGELOG was created starting from version 0.0.0. Earlier changes are not documented here.
@@ -10,8 +9,3 @@ All notable changes to this project will be documented in this file.
 
 
 
-=======
-This file contains a detailed description of changes per release.
-
-## Unreleased
->>>>>>> dc2b1a5 (test: create changelog)


### PR DESCRIPTION
# Release.yml Update

The following release workflow exercise succeeded for PreRelease.yml but Release.yml failed because the tag version was `0.0.0` instead of `v0.0.0`: [Run Link](https://github.com/aws-observability/aws-otel-swift/actions/runs/19344940357/job/55342733669#step:4:35).

Originally, the former was used because SPM recommended `0.0.0`. However, the result of this run indicates that GitHub does not support it. 

Since SPM also supports `v0.0.0`, this change was made.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

