### PR TITLE
fix(release): reorder arguments to gh release create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 # Changelog
 
-<<<<<<< HEAD
 All notable changes to this project will be documented in this file.
 
 > **Note:** This CHANGELOG was created starting from version 0.0.0. Earlier changes are not documented here.
@@ -10,8 +9,3 @@ All notable changes to this project will be documented in this file.
 
 
 
-=======
-This file contains a detailed description of changes per release.
-
-## Unreleased
->>>>>>> dc2b1a5 (test: create changelog)


### PR DESCRIPTION
# Release.yml

The Release.yml workflow was still failing with the same error: https://github.com/aws-observability/aws-otel-swift/actions/runs/19345688314/job/55345346454

Finally root caused the issue to the order of arguments. If a tag does not already exist for that version, then `gh release create` will only create it if the first argument passed is the version number. Eg: `gh release create "${VERSION}"`.

Updated this PR to follow this format.

Additionally, this change removes `.` from the command which was trying to add all files in the root folder as release assets. Instead, we rely on GitHub automatically creating source code zips.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

