### PR TITLE
fix: remove trailing space

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -44,7 +44,7 @@ jobs:
 
           # Tag a GitHub release
           gh release create "${VERSION}" \
-             --target "$GITHUB_REF_NAME" \ 
+             --target "$GITHUB_REF_NAME" \
              --title "Release ${VERSION}" \
              --notes-file release_notes.md \
              --draft 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 # Changelog
 
-<<<<<<< HEAD
 All notable changes to this project will be documented in this file.
 
 > **Note:** This CHANGELOG was created starting from version 0.0.0. Earlier changes are not documented here.
@@ -10,8 +9,3 @@ All notable changes to this project will be documented in this file.
 
 
 
-=======
-This file contains a detailed description of changes per release.
-
-## Unreleased
->>>>>>> dc2b1a5 (test: create changelog)


### PR DESCRIPTION
# Release.yml

Turns out there was a trailing space that's causing this error: https://github.com/aws-observability/aws-otel-swift/actions/runs/19348362304/job/55354294548#step:4:32

Not sure how to avoid issues like this. Happy to look into any suggestions.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

