### PR TITLE
fix: Skip changelog label not properly skipping in static-code-checks

### DIFF
--- a/.github/workflows/BuildAndTest.yml
+++ b/.github/workflows/BuildAndTest.yml
@@ -39,7 +39,7 @@ jobs:
           fi
           
           # Check for skip changelog label
-          if echo '${{ toJSON(github.event.pull_request.labels.*.name) }}' | jq -r '.[]' | grep -q "skip changelog"; then
+          if echo '${{ toJSON(github.event.pull_request.labels.*.name) }}' | jq -r '.[]' | grep -iq "skip changelog"; then
             echo "Skipping check: skip changelog label found"
             exit 0
           fi


### PR DESCRIPTION
The static-code-checks workflow is failing even for changes that are marked w/ the "Skip Changelog" label.

This PR fixes the issue by making the `grep` case-insensitive with the `-i` flag. It was just getting a little annoying to see that workflow failing in PRs.

This same change was applied in the Android repo: https://github.com/aws-observability/aws-otel-android/commit/bca194e307d975f8e9666a0d746d759318c82ed3