### PR TITLE
ci: use minimal GitHub Token permissions in release workflow

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -7,6 +7,8 @@ jobs:
   build:
     environment: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Github Actions best practices.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

