### PR TITLE
fix: Pin opentelemetry-swift dependencies to exact version 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,5 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+- Pin `opentelemetry-swift-core`, `opentelemetry-swift`, `aws-sdk-swift`, and `smithy-swift` to exact versions to prevent SPM from resolving to incompatible newer releases ([#103](https://github.com/aws-observability/aws-otel-swift/pull/103))
 
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/aws-sdk-swift",
       "state" : {
-        "revision" : "224c85b9843ad3b760387c607b1993ac313a6104",
-        "version" : "1.3.43"
+        "revision" : "131e738e8472a1f5d8080c76abf5445a21a3321c",
+        "version" : "1.3.32"
       }
     },
     {
@@ -55,15 +55,6 @@
       }
     },
     {
-      "identity" : "opentracing-objc",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/undefinedlabs/opentracing-objc",
-      "state" : {
-        "revision" : "18c1a35ca966236cee0c5a714a51a73ff33384c1",
-        "version" : "0.5.2"
-      }
-    },
-    {
       "identity" : "plcrashreporter",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/microsoft/plcrashreporter.git",
@@ -77,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/smithy-lang/smithy-swift",
       "state" : {
-        "revision" : "4fd1f783164723094974c7590820874866a67ac2",
-        "version" : "0.141.0"
+        "revision" : "e1638ed20eb1b08fd89b5ce02a55d0160a81e730",
+        "version" : "0.134.0"
       }
     },
     {
@@ -268,15 +259,6 @@
       "state" : {
         "revision" : "395a77f0aa927f0ff73941d7ac35f2b46d47c9db",
         "version" : "1.6.3"
-      }
-    },
-    {
-      "identity" : "thrift-swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/undefinedlabs/Thrift-Swift",
-      "state" : {
-        "revision" : "18ff09e6b30e589ed38f90a1af23e193b8ecef8e",
-        "version" : "1.1.2"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -16,8 +16,8 @@ let package = Package(
     .library(name: "AwsOpenTelemetryAuth", targets: ["AwsOpenTelemetryAuth"])
   ],
   dependencies: [
-    .package(url: "https://github.com/open-telemetry/opentelemetry-swift-core.git", from: "2.2.0"),
-    .package(url: "https://github.com/open-telemetry/opentelemetry-swift.git", from: "2.2.0"),
+    .package(url: "https://github.com/open-telemetry/opentelemetry-swift-core.git", exact: "2.2.0"),
+    .package(url: "https://github.com/open-telemetry/opentelemetry-swift.git", exact: "2.2.0"),
     .package(url: "https://github.com/awslabs/aws-sdk-swift", from: "1.3.32"),
     .package(url: "https://github.com/smithy-lang/smithy-swift", from: "0.134.0"),
     .package(url: "https://github.com/kstenerud/KSCrash.git", .upToNextMajor(from: "2.4.0")),

--- a/Package.swift
+++ b/Package.swift
@@ -18,8 +18,8 @@ let package = Package(
   dependencies: [
     .package(url: "https://github.com/open-telemetry/opentelemetry-swift-core.git", exact: "2.2.0"),
     .package(url: "https://github.com/open-telemetry/opentelemetry-swift.git", exact: "2.2.0"),
-    .package(url: "https://github.com/awslabs/aws-sdk-swift", from: "1.3.32"),
-    .package(url: "https://github.com/smithy-lang/smithy-swift", from: "0.134.0"),
+    .package(url: "https://github.com/awslabs/aws-sdk-swift", exact: "1.3.32"),
+    .package(url: "https://github.com/smithy-lang/smithy-swift", exact: "0.134.0"),
     .package(url: "https://github.com/kstenerud/KSCrash.git", .upToNextMajor(from: "2.4.0")),
     .package(url: "https://github.com/microsoft/plcrashreporter.git", from: "1.11.2") // only used for live stack trace collection, not crash reporting
   ],

--- a/Sources/AwsOpenTelemetryAuth/AwsSigV4Authenticator.swift
+++ b/Sources/AwsOpenTelemetryAuth/AwsSigV4Authenticator.swift
@@ -143,9 +143,7 @@ public class AwsSigV4Authenticator {
       guard let signedRequest = await signer.sigV4SignedRequest(requestBuilder: requestBuilder, signingConfig: config) else {
         return urlRequest
       }
-      let request = try await SmithyHTTPAPI.HTTPRequest.makeURLRequest(from: signedRequest)
-
-      return request
+      return try await SmithyHTTPAPI.HTTPRequest.makeURLRequest(from: signedRequest)
     } catch {
       AwsInternalLogger.error("Error signing request: \(error)")
       return urlRequest

--- a/Sources/AwsOpenTelemetryCore/AppLaunch/AppLaunchProvider.swift
+++ b/Sources/AwsOpenTelemetryCore/AppLaunch/AppLaunchProvider.swift
@@ -36,7 +36,7 @@ public protocol AppLaunchProvider {
   /// Threshold above which a launch is considered pre-warm
   var preWarmFallbackThreshold: TimeInterval { get }
 
-  // Notification after which warm launches are allowed to be reported
+  /// Notification after which warm launches are allowed to be reported
   var hiddenNotification: Notification.Name { get }
 
   /// Additional lifecycle events to record as log events

--- a/Sources/AwsOpenTelemetryCore/AppLaunch/AwsAppLaunchInstrumentation.swift
+++ b/Sources/AwsOpenTelemetryCore/AppLaunch/AwsAppLaunchInstrumentation.swift
@@ -20,8 +20,8 @@ import OpenTelemetryApi
   import UIKit
 #endif
 
-// We want to capture active prewarm flag as early as possible, since it allegedly gets cleared
-// after `UIApplication.didFinishLaunchingNotification`
+/// We want to capture active prewarm flag as early as possible, since it allegedly gets cleared
+/// after `UIApplication.didFinishLaunchingNotification`
 let isActivePrewarm: Bool = ProcessInfo.processInfo.environment["ActivePrewarm"] != nil
 
 protocol AppLaunchProtocol {
@@ -35,7 +35,7 @@ public class AwsAppLaunchInstrumentation: NSObject, AppLaunchProtocol {
   static var provider: AppLaunchProvider?
   private static let lock: NSLock = .init()
 
-  // We need static reference to persist the observers
+  /// We need static reference to persist the observers
   static var shared: AwsAppLaunchInstrumentation?
 
   // Observer references for cleanup

--- a/Sources/AwsOpenTelemetryCore/Builder/AwsOpenTelemetryRumBuilder.swift
+++ b/Sources/AwsOpenTelemetryCore/Builder/AwsOpenTelemetryRumBuilder.swift
@@ -14,7 +14,6 @@
  */
 
 import Foundation
-
 import OpenTelemetryApi
 import OpenTelemetryProtocolExporterCommon
 import OpenTelemetryProtocolExporterHttp
@@ -250,9 +249,7 @@ public class AwsOpenTelemetryRumBuilder {
    * @return This builder instance for method chaining
    */
   @discardableResult
-  public func addSpanExporterCustomizer(
-    _ customizer: @escaping (SpanExporter) -> SpanExporter
-  ) -> Self {
+  public func addSpanExporterCustomizer(_ customizer: @escaping (SpanExporter) -> SpanExporter) -> Self {
     let existing = spanExporterCustomizer
     spanExporterCustomizer = { exporter in
       let intermediate = existing(exporter)
@@ -277,9 +274,7 @@ public class AwsOpenTelemetryRumBuilder {
    * @return This builder instance for method chaining
    */
   @discardableResult
-  public func addLogRecordExporterCustomizer(
-    _ customizer: @escaping (LogRecordExporter) -> LogRecordExporter
-  ) -> Self {
+  public func addLogRecordExporterCustomizer(_ customizer: @escaping (LogRecordExporter) -> LogRecordExporter) -> Self {
     let existing = logRecordExporterCustomizer
     logRecordExporterCustomizer = { exporter in
       let intermediate = existing(exporter)
@@ -306,9 +301,7 @@ public class AwsOpenTelemetryRumBuilder {
    * @return This builder instance for method chaining
    */
   @discardableResult
-  public func addTracerProviderCustomizer(
-    _ customizer: @escaping (TracerProviderBuilder) -> TracerProviderBuilder
-  ) -> Self {
+  public func addTracerProviderCustomizer(_ customizer: @escaping (TracerProviderBuilder) -> TracerProviderBuilder) -> Self {
     tracerProviderCustomizers.append(customizer)
     return self
   }
@@ -329,9 +322,7 @@ public class AwsOpenTelemetryRumBuilder {
    * @return This builder instance for method chaining
    */
   @discardableResult
-  public func addLoggerProviderCustomizer(
-    _ customizer: @escaping (LoggerProviderBuilder) -> LoggerProviderBuilder
-  ) -> Self {
+  public func addLoggerProviderCustomizer(_ customizer: @escaping (LoggerProviderBuilder) -> LoggerProviderBuilder) -> Self {
     loggerProviderCustomizers.append(customizer)
     return self
   }

--- a/Sources/AwsOpenTelemetryCore/Builder/AwsOpenTelemetryUtils.swift
+++ b/Sources/AwsOpenTelemetryCore/Builder/AwsOpenTelemetryUtils.swift
@@ -63,7 +63,5 @@ public func buildOtlpEndpoints(region: String, exportOverride: AwsExportOverride
   let logsEndpoint = buildLogsEndpoint(region: region, exportOverride: exportOverride)
 
   // Use Set to automatically handle duplicates when traces and logs use the same endpoint
-  let endpoints = Set([tracesEndpoint, logsEndpoint])
-
-  return endpoints
+  return Set([tracesEndpoint, logsEndpoint])
 }

--- a/Sources/AwsOpenTelemetryCore/Configuration/AwsOpenTelemetryConfig.swift
+++ b/Sources/AwsOpenTelemetryCore/Configuration/AwsOpenTelemetryConfig.swift
@@ -83,7 +83,7 @@ import Foundation
     return AwsOpenTelemetryConfigBuilder()
   }
 
-  // Custom decoder implementation to handle default values
+  /// Custom decoder implementation to handle default values
   public required init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     aws = try container.decode(AwsConfig.self, forKey: .aws)

--- a/Sources/AwsOpenTelemetryCore/DeviceKit/AwsDeviceKitSemConv.swift
+++ b/Sources/AwsOpenTelemetryCore/DeviceKit/AwsDeviceKitSemConv.swift
@@ -22,10 +22,10 @@ import Foundation
 /// typically recorded as metrics, but we will record them as log/span attributes
 /// given that metrics are typically not individually recorded client-side.
 public class AwsDeviceKitSemConv {
-  // battery - https://opentelemetry.io/docs/specs/semconv/hardware/battery/
+  /// battery - https://opentelemetry.io/docs/specs/semconv/hardware/battery/
   public static let batteryCharge = "hw.battery.charge"
-  // cpu - https://opentelemetry.io/docs/specs/semconv/system/process-metrics/
+  /// cpu - https://opentelemetry.io/docs/specs/semconv/system/process-metrics/
   public static let cpuUtilization = "process.cpu.utilization"
-  // mem - https://opentelemetry.io/docs/specs/semconv/system/process-metrics/#metric-processmemoryusage
+  /// mem - https://opentelemetry.io/docs/specs/semconv/system/process-metrics/#metric-processmemoryusage
   public static let memoryUsage = "process.memory.usage"
 }

--- a/Sources/AwsOpenTelemetryCore/DeviceKit/DeviceKitPolyfill.swift
+++ b/Sources/AwsOpenTelemetryCore/DeviceKit/DeviceKitPolyfill.swift
@@ -47,11 +47,10 @@ public class DeviceKitPolyfill: DeviceKitPolyfillProtocol {
     uname(&systemInfo)
     let mirror = Mirror(reflecting: systemInfo.machine)
 
-    let identifier = mirror.children.reduce("") { identifier, element in
+    return mirror.children.reduce("") { identifier, element in
       guard let value = element.value as? Int8, value != 0 else { return identifier }
       return identifier + String(UnicodeScalar(UInt8(value)))
     }
-    return identifier
   }()
 
   /// Maps device identifier to human-readable device name
@@ -362,7 +361,7 @@ public class DeviceKitPolyfill: DeviceKitPolyfillProtocol {
       var count = mach_msg_type_number_t(MemoryLayout<mach_task_basic_info>.size) / 4
 
       // Get RSS memory via `task_info` API
-      /// https://web.mit.edu/darwin/src/modules/xnu/osfmk/man/task_info.html
+      // https://web.mit.edu/darwin/src/modules/xnu/osfmk/man/task_info.html
       let result = withUnsafeMutablePointer(to: &info) { structPointer in
         // See https://developer.apple.com/documentation/swift/unsafemutablepointer/withmemoryrebound(to:capacity:_:)
         structPointer.withMemoryRebound(

--- a/Sources/AwsOpenTelemetryCore/Hang/AwsHangInstrumentation.swift
+++ b/Sources/AwsOpenTelemetryCore/Hang/AwsHangInstrumentation.swift
@@ -71,8 +71,8 @@ public class AwsHangInstrumentation {
     }
   }
 
-  // We use run loop hang to report hangs because of its precision and ability to
-  // handle edge cases without much hassle (e.g. when application is moved to background)
+  /// We use run loop hang to report hangs because of its precision and ability to
+  /// handle edge cases without much hassle (e.g. when application is moved to background)
   func setupRunLoopObserver() {
     let observer = CFRunLoopObserverCreateWithHandler(nil, CFRunLoopActivity.beforeWaiting.rawValue | CFRunLoopActivity.afterWaiting.rawValue, true, 0) { [weak self] _, activity in
       guard let self else { return }
@@ -98,9 +98,9 @@ public class AwsHangInstrumentation {
     CFRunLoopAddObserver(CFRunLoopGetMain(), observer, CFRunLoopMode.commonModes)
   }
 
-  // We need to use the "background ping" strategy to preemptively collect the live stack
-  // trace before the main thread has recovered. This must be done from a background thread
-  // because the main thread is obviously unavailable during a hang.
+  /// We need to use the "background ping" strategy to preemptively collect the live stack
+  /// trace before the main thread has recovered. This must be done from a background thread
+  /// because the main thread is obviously unavailable during a hang.
   func startBackgroundMonitoring() {
     monitoringTimer = DispatchSource.makeTimerSource(queue: watchdogQueue)
     monitoringTimer?.schedule(deadline: .now(), repeating: .milliseconds(100))

--- a/Sources/AwsOpenTelemetryCore/Hang/LiveStackTraceReporter.swift
+++ b/Sources/AwsOpenTelemetryCore/Hang/LiveStackTraceReporter.swift
@@ -73,8 +73,8 @@ public protocol LiveStackTraceReporter {
       return StackTrace(message: message, stacktrace: stacktrace)
     }
 
-    // For simplicity, we only do library name + offset to help with grouping. If we include the full first frame, then
-    // unfortunately every exception message becomes unique.
+    /// For simplicity, we only do library name + offset to help with grouping. If we include the full first frame, then
+    /// unfortunately every exception message becomes unique.
     func getFirstFrameOfMain(stacktrace: String) -> String? {
       guard let firstFrameLine = stacktrace.components(separatedBy: "Thread 0:\n0").dropFirst().first?.components(separatedBy: "\n").first?.trimmingCharacters(in: .whitespaces) else {
         return nil
@@ -94,7 +94,7 @@ public protocol LiveStackTraceReporter {
   }
 #endif
 
-// Noop implementation for platforms where PLCrashReporter is not available
+/// Noop implementation for platforms where PLCrashReporter is not available
 public class NoopLiveStackTraceReporter: LiveStackTraceReporter {
   public let maxStackTraceLength: Int
 

--- a/Sources/AwsOpenTelemetryCore/KSCrash/AwsCrashSemConv.swift
+++ b/Sources/AwsOpenTelemetryCore/KSCrash/AwsCrashSemConv.swift
@@ -27,13 +27,13 @@ public class AwsExceptionSemConv {
   static let type = "exception.type"
   static let stacktrace = "exception.stacktrace"
 
-  // in-house utility field for context recovery
-  // when true, then the following fields are recovered
-  // 1. `session.id`
-  // 2. `session.previous_id`
-  // 3. `screen.name`
-  // 4. `user.id`
-  // 5. original timestamp
+  /// in-house utility field for context recovery
+  /// when true, then the following fields are recovered
+  /// 1. `session.id`
+  /// 2. `session.previous_id`
+  /// 3. `screen.name`
+  /// 4. `user.id`
+  /// 5. original timestamp
   static let recoveredContext = "recovered_context"
 }
 

--- a/Sources/AwsOpenTelemetryCore/KSCrash/AwsKSCrashInstrumentation.swift
+++ b/Sources/AwsOpenTelemetryCore/KSCrash/AwsKSCrashInstrumentation.swift
@@ -183,7 +183,7 @@ public class AwsKSCrashInstrumentation: CrashProtocol {
     AwsInternalLogger.debug("AwsKSCrashInstrumentation processed \(reportIDs.count) stored crashes")
   }
 
-  // Report a KSCrash report in Apple format
+  /// Report a KSCrash report in Apple format
   private static func reportCrash(crashReport: CrashReportDictionary) {
     let rawCrash: [String: Any] = crashReport.value
     let log: any LogRecordBuilder = logger.logRecordBuilder()

--- a/Sources/AwsOpenTelemetryCore/Network/AwsURLSessionInstrumentation.swift
+++ b/Sources/AwsOpenTelemetryCore/Network/AwsURLSessionInstrumentation.swift
@@ -58,8 +58,7 @@ public class AwsURLSessionInstrumentation {
 
     let urlSessionConfig = URLSessionInstrumentationConfiguration(
       shouldInstrument: { request in
-        let shouldInstrument = !self.shouldExcludeURL(request)
-        return shouldInstrument
+        return !self.shouldExcludeURL(request)
       }
     )
     _ = URLSessionInstrumentation(configuration: urlSessionConfig)

--- a/Sources/AwsOpenTelemetryCore/ScreenManager/AwsScreenManager.swift
+++ b/Sources/AwsOpenTelemetryCore/ScreenManager/AwsScreenManager.swift
@@ -68,7 +68,7 @@ public class AwsScreenManager {
     }
   }
 
-  // constructor
+  /// constructor
   init(queue: DispatchQueue = DispatchQueue(label: queueLabel, qos: .utility)) {
     self.queue = queue
   }

--- a/Sources/AwsOpenTelemetryCore/Sessions/AwsSession.swift
+++ b/Sources/AwsOpenTelemetryCore/Sessions/AwsSession.swift
@@ -64,15 +64,6 @@ public struct AwsSession: Equatable {
     self.sessionTimeout = sessionTimeout
   }
 
-  /// Two sessions are considered equal if they have the same ID, prevID, startTime, and expiry timestamp
-  public static func == (lhs: AwsSession, rhs: AwsSession) -> Bool {
-    return lhs.expireTime == rhs.expireTime &&
-      lhs.id == rhs.id &&
-      lhs.previousId == rhs.previousId &&
-      lhs.startTime == rhs.startTime &&
-      lhs.sessionTimeout == rhs.sessionTimeout
-  }
-
   /// Checks if the session has expired
   /// - Returns: True if the current time is past the session's expireTime time
   public func isExpired() -> Bool {

--- a/Sources/AwsOpenTelemetryCore/Sessions/AwsSessionEventInstrumentation.swift
+++ b/Sources/AwsOpenTelemetryCore/Sessions/AwsSessionEventInstrumentation.swift
@@ -118,8 +118,8 @@ public class AwsSessionEventInstrumentation {
       attributes[AwsSessionSemConv.previousId] = AttributeValue.string(previousId)
     }
 
-    /// Create `session.start` log record according to otel semantic convention
-    /// https://opentelemetry.io/docs/specs/semconv/general/session/
+    // Create `session.start` log record according to otel semantic convention
+    // https://opentelemetry.io/docs/specs/semconv/general/session/
     logger.logRecordBuilder()
       .setEventName(AwsSessionStartSemConv.name)
       .setAttributes(attributes)
@@ -146,8 +146,8 @@ public class AwsSessionEventInstrumentation {
       attributes[AwsSessionSemConv.previousId] = AttributeValue.string(previousId)
     }
 
-    /// Create `session.end`` log record according to otel semantic convention
-    /// https://opentelemetry.io/docs/specs/semconv/general/session/
+    // Create `session.end`` log record according to otel semantic convention
+    // https://opentelemetry.io/docs/specs/semconv/general/session/
     logger.logRecordBuilder()
       .setEventName(AwsSessionEndSemConv.name)
       .setAttributes(attributes)
@@ -166,8 +166,8 @@ public class AwsSessionEventInstrumentation {
     if isApplied {
       createSessionEvent(session: session, eventType: eventType)
     } else {
-      /// SessionManager creates sessions before SessionEventInstrumentation is applied,
-      /// which the notification observer cannot see. So we need to keep the sessions in a queue.
+      // SessionManager creates sessions before SessionEventInstrumentation is applied,
+      // which the notification observer cannot see. So we need to keep the sessions in a queue.
       if queue.count >= maxQueueSize {
         AwsInternalLogger.debug("Queue at max capacity (\(maxQueueSize)), dropping latest session event: \(session.id)")
         return

--- a/Sources/AwsOpenTelemetryCore/Sessions/AwsSessionManager.swift
+++ b/Sources/AwsOpenTelemetryCore/Sessions/AwsSessionManager.swift
@@ -97,7 +97,7 @@ public class AwsSessionManager {
       sessionTimeout: configuration.sessionTimeout
     )
 
-    /// Queue the previous session for a `session.end` event
+    // Queue the previous session for a `session.end` event
     if let previousSession {
       AwsSessionEventInstrumentation.addSession(session: previousSession, eventType: .end)
     }

--- a/Sources/AwsOpenTelemetryCore/Sessions/AwsSessionSemConv.swift
+++ b/Sources/AwsOpenTelemetryCore/Sessions/AwsSessionSemConv.swift
@@ -21,7 +21,6 @@ import Foundation
 /// semantic conventions for session tracking.
 ///
 /// Reference: https://opentelemetry.io/docs/specs/semconv/general/session/
-
 public class AwsSessionSemConv {
   public static let id = "session.id"
   public static let previousId = "session.previous_id"

--- a/Sources/AwsOpenTelemetryCore/Sessions/AwsSessionStore.swift
+++ b/Sources/AwsOpenTelemetryCore/Sessions/AwsSessionStore.swift
@@ -29,8 +29,8 @@ class AwsSessionStore {
   /// UserDefaults key for storing session timeout
   static let sessionTimeoutKey = "aws-rum-session-timeout"
 
-  /// To avoid writing to disk too often, SessionStore only keeps the current session
-  /// in memory and saves to disk on an interval (every 30 seconds).
+  // To avoid writing to disk too often, SessionStore only keeps the current session
+  // in memory and saves to disk on an interval (every 30 seconds).
 
   /// The most recent session to be saved to disk
   private static var pendingSession: AwsSession?

--- a/Sources/AwsOpenTelemetryCore/UIKit/AwsUIKitViewInstrumentation.swift
+++ b/Sources/AwsOpenTelemetryCore/UIKit/AwsUIKitViewInstrumentation.swift
@@ -18,20 +18,17 @@
   import OpenTelemetryApi
   import ObjectiveC.runtime
 
-  /**
-   * Main orchestrator for automatic UIKit view controller lifecycle instrumentation.
-   * AwsUIKitViewInstrumentation is automatically created and installed when the AWS OpenTelemetry SDK
-   * is initialized with UIKit instrumentation enabled (default behavior).
-   *
-   * This class provides comprehensive instrumentation of UIViewController lifecycle events,
-   * automatically creating OpenTelemetry spans to track view performance and user navigation
-   * patterns without requiring manual instrumentation code.
-   *
-   * For advanced use cases, you can create and configure the instrumentation manually.
-   * View controllers can implement `AwsViewControllerCustomization`
-   * to control instrumentation.
-   */
-
+  /// Main orchestrator for automatic UIKit view controller lifecycle instrumentation.
+  /// AwsUIKitViewInstrumentation is automatically created and installed when the AWS OpenTelemetry SDK
+  /// is initialized with UIKit instrumentation enabled (default behavior).
+  ///
+  /// This class provides comprehensive instrumentation of UIViewController lifecycle events,
+  /// automatically creating OpenTelemetry spans to track view performance and user navigation
+  /// patterns without requiring manual instrumentation code.
+  ///
+  /// For advanced use cases, you can create and configure the instrumentation manually.
+  /// View controllers can implement `AwsViewControllerCustomization`
+  /// to control instrumentation.
   public final class AwsUIKitViewInstrumentation {
     /// The handler responsible for processing view controller lifecycle events
     /// This component manages the actual span creation and lifecycle tracking

--- a/Sources/AwsOpenTelemetryCore/UIKit/AwsViewControllerCustomization.swift
+++ b/Sources/AwsOpenTelemetryCore/UIKit/AwsViewControllerCustomization.swift
@@ -72,10 +72,14 @@
    */
   public extension AwsViewControllerCustomization where Self: UIViewController {
     /// Default: Use the class name for telemetry
-    var customScreenName: String? { nil }
+    var customScreenName: String? {
+      nil
+    }
 
     /// Default: Enable instrumentation for all view controllers
-    var shouldCaptureView: Bool { true }
+    var shouldCaptureView: Bool {
+      true
+    }
   }
 
 #endif

--- a/scripts/validate-pinned-deps.sh
+++ b/scripts/validate-pinned-deps.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Validates that critical dependencies are pinned to exact versions in Package.swift.
+# Returns non-zero if any dependency uses a range (from:) instead of exact pin.
+
+set -euo pipefail
+
+PACKAGE_SWIFT="${1:-Package.swift}"
+
+FAILURES=0
+
+check_exact_pin() {
+  local dep_url="$1"
+  local expected_version="$2"
+  local dep_name
+  dep_name=$(basename "$dep_url" .git)
+
+  if grep -q "\"$dep_url\".*exact.*\"$expected_version\"" "$PACKAGE_SWIFT"; then
+    echo "✓ $dep_name pinned to exact $expected_version"
+  elif grep -q "\"$dep_url\"" "$PACKAGE_SWIFT"; then
+    echo "✗ $dep_name NOT pinned to exact $expected_version"
+    FAILURES=$((FAILURES + 1))
+  else
+    echo "? $dep_name not found in $PACKAGE_SWIFT"
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+echo "Validating dependency pins in $PACKAGE_SWIFT..."
+echo
+
+check_exact_pin "https://github.com/open-telemetry/opentelemetry-swift-core.git" "2.2.0"
+check_exact_pin "https://github.com/open-telemetry/opentelemetry-swift.git" "2.2.0"
+check_exact_pin "https://github.com/awslabs/aws-sdk-swift" "1.3.32"
+check_exact_pin "https://github.com/smithy-lang/smithy-swift" "0.134.0"
+
+echo
+if [ "$FAILURES" -gt 0 ]; then
+  echo "FAILED: $FAILURES dependencies not pinned correctly"
+  exit 1
+else
+  echo "PASSED: All critical dependencies pinned to exact versions"
+  exit 0
+fi


### PR DESCRIPTION
## Summary

- Pins `opentelemetry-swift-core` and `opentelemetry-swift` to exact version `2.2.0` in `Package.swift`
- The previous `from: "2.2.0"` specifier allowed SPM to resolve to newer versions (2.4.x) which produce OTLP payload formats the RUM data plane rejects ("Valid Records: 0; Invalid Records: 2")
- This is a temporary pin until we validate compatibility with newer OpenTelemetry versions

## Root Cause

Swift Package Manager resolves `from: "2.2.0"` to the latest semver-compatible version. When opentelemetry-swift released 2.4.x, the payload format changed in a way that the AWS RUM data plane no longer accepts, causing all events to be rejected as invalid.

## Test plan

- [x] Verify `swift package resolve` completes successfully with the pinned versions
- [x] Build the package to confirm no compilation errors
- [x] Confirm RUM data plane accepts events from an app using this SDK version

SIM: https://t.corp.amazon.com/P437086465