### PR TITLE
feat: Replace PLCrashReporter with KSCrash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Changed
+- Replace PLCrashReporter with KSCrash backtrace for live stack trace collection in hang detection ([#104](https://github.com/aws-observability/aws-otel-swift/pull/104))
+
 ### Fixed
 - Pin `opentelemetry-swift-core`, `opentelemetry-swift`, `aws-sdk-swift`, and `smithy-swift` to exact versions to prevent SPM from resolving to incompatible newer releases ([#103](https://github.com/aws-observability/aws-otel-swift/pull/103))
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -55,15 +55,6 @@
       }
     },
     {
-      "identity" : "plcrashreporter",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/microsoft/plcrashreporter.git",
-      "state" : {
-        "revision" : "0254f941c646b1ed17b243654723d0f071e990d0",
-        "version" : "1.12.2"
-      }
-    },
-    {
       "identity" : "smithy-swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/smithy-lang/smithy-swift",

--- a/Package.swift
+++ b/Package.swift
@@ -20,8 +20,7 @@ let package = Package(
     .package(url: "https://github.com/open-telemetry/opentelemetry-swift.git", exact: "2.2.0"),
     .package(url: "https://github.com/awslabs/aws-sdk-swift", exact: "1.3.32"),
     .package(url: "https://github.com/smithy-lang/smithy-swift", exact: "0.134.0"),
-    .package(url: "https://github.com/kstenerud/KSCrash.git", .upToNextMajor(from: "2.4.0")),
-    .package(url: "https://github.com/microsoft/plcrashreporter.git", from: "1.11.2") // only used for live stack trace collection, not crash reporting
+    .package(url: "https://github.com/kstenerud/KSCrash.git", .upToNextMajor(from: "2.4.0"))
   ],
   targets: [
     .target(
@@ -32,7 +31,7 @@ let package = Package(
         .product(name: "OpenTelemetryProtocolExporterHTTP", package: "opentelemetry-swift"),
         .product(name: "URLSessionInstrumentation", package: "opentelemetry-swift"),
         .product(name: "Installations", package: "KSCrash"),
-        .product(name: "CrashReporter", package: "plcrashreporter", condition: .when(platforms: [.iOS, .macOS, .tvOS, .visionOS]))
+        .product(name: "Recording", package: "KSCrash")
       ],
       exclude: ["Sessions/README.md", "Network/README.md", "User/README.md", "GlobalAttributes/README.md", "UIKit/README.md", "AppLaunch/README.md", "SwiftUI/README.md"]
     ),

--- a/Sources/AwsOpenTelemetryCore/Hang/AwsHangInstrumentation.swift
+++ b/Sources/AwsOpenTelemetryCore/Hang/AwsHangInstrumentation.swift
@@ -44,13 +44,12 @@ public class AwsHangInstrumentation {
   static let shared = AwsHangInstrumentation()
 
   public init(stackTraceCollector: LiveStackTraceReporter? = nil) {
-    let collector: LiveStackTraceReporter
-    if let stackTraceCollector {
-      collector = stackTraceCollector
+    let collector: LiveStackTraceReporter = if let stackTraceCollector {
+      stackTraceCollector
     } else {
-      collector = KSCrashLiveStackTraceReporter()
+      KSCrashLiveStackTraceReporter()
     }
-    hangPredetectionThreshold = hangThreshold * 2 / 3 // lower threshold to collect stacktrace during ongoing hangs
+    hangPredetectionThreshold = hangThreshold * 2 / 3
     tracer = OpenTelemetry.instance.tracerProvider.get(instrumentationName: AwsInstrumentationScopes.HANG)
     logger = OpenTelemetry.instance.loggerProvider.get(instrumentationScopeName: AwsInstrumentationScopes.HANG)
     self.stackTraceCollector = collector

--- a/Sources/AwsOpenTelemetryCore/Hang/AwsHangInstrumentation.swift
+++ b/Sources/AwsOpenTelemetryCore/Hang/AwsHangInstrumentation.swift
@@ -48,11 +48,7 @@ public class AwsHangInstrumentation {
     if let stackTraceCollector {
       collector = stackTraceCollector
     } else {
-      #if !os(watchOS)
-        collector = PLLiveStackTraceReporter()
-      #else
-        collector = NoopLiveStackTraceReporter()
-      #endif
+      collector = KSCrashLiveStackTraceReporter()
     }
     hangPredetectionThreshold = hangThreshold * 2 / 3 // lower threshold to collect stacktrace during ongoing hangs
     tracer = OpenTelemetry.instance.tracerProvider.get(instrumentationName: AwsInstrumentationScopes.HANG)
@@ -63,6 +59,9 @@ public class AwsHangInstrumentation {
 
   func startWatchdog() {
     DispatchQueue.main.async {
+      if let ksReporter = self.stackTraceCollector as? KSCrashLiveStackTraceReporter {
+        ksReporter.setTargetThread(pthread_self())
+      }
       self.setupRunLoopObserver()
     }
 

--- a/Sources/AwsOpenTelemetryCore/Hang/LiveStackTraceReporter.swift
+++ b/Sources/AwsOpenTelemetryCore/Hang/LiveStackTraceReporter.swift
@@ -38,7 +38,7 @@ public class KSCrashLiveStackTraceReporter: LiveStackTraceReporter {
   }
 
   public func setTargetThread(_ thread: pthread_t) {
-    self.targetThread = thread
+    targetThread = thread
   }
 
   public func generateLiveStackTrace() -> Data? {
@@ -105,4 +105,3 @@ public class NoopLiveStackTraceReporter: LiveStackTraceReporter {
     return StackTrace(message: "Stack trace collection not available", stacktrace: "Stack trace collection not supported on this platform")
   }
 }
-

--- a/Sources/AwsOpenTelemetryCore/Hang/LiveStackTraceReporter.swift
+++ b/Sources/AwsOpenTelemetryCore/Hang/LiveStackTraceReporter.swift
@@ -14,9 +14,7 @@
  */
 
 import Foundation
-#if !os(watchOS)
-  import CrashReporter
-#endif
+import KSCrashRecordingCore
 
 public struct StackTrace {
   let message: String
@@ -30,71 +28,68 @@ public protocol LiveStackTraceReporter {
   init(maxStackTraceLength: Int)
 }
 
-#if !os(watchOS)
-  public class PLLiveStackTraceReporter: LiveStackTraceReporter {
-    let reporter: PLCrashReporter
-    public let maxStackTraceLength: Int
+public class KSCrashLiveStackTraceReporter: LiveStackTraceReporter {
+  public let maxStackTraceLength: Int
+  private let maxFrames = 128
+  private var targetThread: pthread_t?
 
-    public required init(maxStackTraceLength: Int = 10 * 1000) {
-      self.maxStackTraceLength = maxStackTraceLength
-      let config = PLCrashReporterConfig(
-        signalHandlerType: .BSD,
-        symbolicationStrategy: [] // empty list means no symbolication, and implies a ~20 ms fetch time
-        // To get on-device symbolication during development, set symbolicationStrategy to
-        // - `.all` (2 sec blocking delay)
-        // - `.symbolTable` (1 sec blocking delay)
-      )
-      // PLCrashReporter is designed for crash reports but we are able to take advantage of its live report feature,
-      // which is perfect for collecting stack traces associated with app hangs. This does not interfere with other
-      // crash reporters because we are not using the crash report feature.
-      reporter = PLCrashReporter(configuration: config)
-    }
-
-    public func generateLiveStackTrace() -> Data? {
-      return reporter.generateLiveReport()
-    }
-
-    public func formatStackTrace(rawStackTrace: Data) -> StackTrace {
-      var stacktrace = "Failed to collect stack trace"
-      var message = "Hang detected at unknown location"
-      do {
-        let crashReport = try PLCrashReport(data: rawStackTrace)
-        if let fullStacktrace = PLCrashReportTextFormatter.stringValue(for: crashReport, with: PLCrashReportTextFormatiOS) {
-          stacktrace = String(fullStacktrace.prefix(maxStackTraceLength))
-          let firstFrame = getFirstFrameOfMain(stacktrace: stacktrace) ?? "unknown location"
-          message = "Hang detected at \(firstFrame)"
-        } else {
-          AwsInternalLogger.error("PLLiveStackTraceReporter: Failed to format crash report to string")
-        }
-      } catch {
-        AwsInternalLogger.error("PLLiveStackTraceReporter: Failed to parse crash report: \(error)")
-        stacktrace = "Failed to parse stack trace: \(error)"
-      }
-      return StackTrace(message: message, stacktrace: stacktrace)
-    }
-
-    /// For simplicity, we only do library name + offset to help with grouping. If we include the full first frame, then
-    /// unfortunately every exception message becomes unique.
-    func getFirstFrameOfMain(stacktrace: String) -> String? {
-      guard let firstFrameLine = stacktrace.components(separatedBy: "Thread 0:\n0").dropFirst().first?.components(separatedBy: "\n").first?.trimmingCharacters(in: .whitespaces) else {
-        return nil
-      }
-
-      // Extract library name and offset from frame like:
-      // "   libsystem_kernel.dylib              0x00000001dccb1658 0x1dccab000 + 26200"
-      let components = firstFrameLine.components(separatedBy: .whitespaces).filter { !$0.isEmpty }
-      guard components.count >= 4,
-            let libraryName = components.first,
-            let offsetString = components.last else {
-        return "unknown location"
-      }
-
-      return "\(libraryName) + \(offsetString)"
-    }
+  public required init(maxStackTraceLength: Int = 10 * 1000) {
+    self.maxStackTraceLength = maxStackTraceLength
   }
-#endif
 
-/// Noop implementation for platforms where PLCrashReporter is not available
+  public func setTargetThread(_ thread: pthread_t) {
+    self.targetThread = thread
+  }
+
+  public func generateLiveStackTrace() -> Data? {
+    guard let thread = targetThread else {
+      return nil
+    }
+    var addresses = [UInt](repeating: 0, count: maxFrames)
+    let count = captureBacktrace(thread: thread, addresses: &addresses, count: Int32(maxFrames))
+    guard count > 0 else {
+      return nil
+    }
+    let captured = Array(addresses.prefix(Int(count)))
+    return try? JSONEncoder().encode(captured)
+  }
+
+  public func formatStackTrace(rawStackTrace: Data) -> StackTrace {
+    guard let addresses = try? JSONDecoder().decode([UInt].self, from: rawStackTrace), !addresses.isEmpty else {
+      return StackTrace(message: "Hang detected at unknown location", stacktrace: "Failed to parse stack trace")
+    }
+
+    var lines: [String] = []
+    var firstFrameDescription: String?
+
+    for (index, address) in addresses.enumerated() {
+      var info = SymbolInformation()
+      let success = symbolicate(address: address, result: &info)
+
+      let line: String
+      if success {
+        let imageName = info.imageName.map { String(cString: $0).components(separatedBy: "/").last ?? String(cString: $0) } ?? "???"
+        let symbolName = info.symbolName.map { String(cString: $0) } ?? "0x\(String(address, radix: 16))"
+        let offset = address - info.symbolAddress
+        line = "\(index)\t\(imageName)\t\(symbolName) + \(offset)"
+
+        if index == 0 {
+          firstFrameDescription = "\(imageName) + \(offset)"
+        }
+      } else {
+        line = "\(index)\t???\t0x\(String(address, radix: 16))"
+      }
+      lines.append(line)
+    }
+
+    let fullTrace = "Thread 0:\n" + lines.joined(separator: "\n")
+    let stacktrace = String(fullTrace.prefix(maxStackTraceLength))
+    let message = "Hang detected at \(firstFrameDescription ?? "unknown location")"
+    return StackTrace(message: message, stacktrace: stacktrace)
+  }
+}
+
+/// Noop implementation for platforms where live stack trace collection is unavailable
 public class NoopLiveStackTraceReporter: LiveStackTraceReporter {
   public let maxStackTraceLength: Int
 
@@ -110,3 +105,4 @@ public class NoopLiveStackTraceReporter: LiveStackTraceReporter {
     return StackTrace(message: "Stack trace collection not available", stacktrace: "Stack trace collection not supported on this platform")
   }
 }
+

--- a/Tests/AwsOpenTelemetryCoreTests/Hang/LiveStackTraceReporterTests.swift
+++ b/Tests/AwsOpenTelemetryCoreTests/Hang/LiveStackTraceReporterTests.swift
@@ -1,8 +1,5 @@
 import XCTest
 @testable import AwsOpenTelemetryCore
-#if !os(watchOS)
-  import CrashReporter
-#endif
 
 // MARK: - NoopLiveStackTraceReporter Tests
 
@@ -43,132 +40,77 @@ final class NoopLiveStackTraceReporterTests: XCTestCase {
   }
 }
 
-#if !os(watchOS)
+// MARK: - KSCrashLiveStackTraceReporter Tests
 
-  // MARK: - PLStackTraceReporterTests Tests
+final class KSCrashLiveStackTraceReporterTests: XCTestCase {
+  var collector: KSCrashLiveStackTraceReporter!
 
-  final class PLLiveStackTraceReporterTests: XCTestCase {
-    var collector: PLLiveStackTraceReporter!
-
-    override func setUp() {
-      super.setUp()
-      collector = PLLiveStackTraceReporter(maxStackTraceLength: 1000)
-    }
-
-    override func tearDown() {
-      collector = nil
-      super.tearDown()
-    }
-
-    func testInitialization() {
-      XCTAssertEqual(collector.maxStackTraceLength, 1000)
-      XCTAssertNotNil(collector.reporter)
-    }
-
-    func testDefaultInitialization() {
-      let defaultCollector = PLLiveStackTraceReporter()
-      XCTAssertEqual(defaultCollector.maxStackTraceLength, 10000)
-    }
-
-    func testGenerateLiveStackTrace() {
-      XCTAssertNoThrow(collector.generateLiveStackTrace())
-    }
-
-    func testFormatStackTraceWithInvalidData() {
-      let invalidData = "invalid crash report data".data(using: .utf8)!
-      let result = collector.formatStackTrace(rawStackTrace: invalidData)
-
-      XCTAssertEqual(result.message, "Hang detected at unknown location")
-      XCTAssertTrue(result.stacktrace.contains("Failed to parse stack trace"))
-    }
-
-    func testFormatStackTraceWithEmptyData() {
-      let emptyData = Data()
-      let result = collector.formatStackTrace(rawStackTrace: emptyData)
-
-      XCTAssertEqual(result.message, "Hang detected at unknown location")
-      XCTAssertTrue(result.stacktrace.contains("Failed to parse stack trace"))
-    }
-
-    func testMaxStackTraceLengthTruncation() {
-      let shortCollector = PLLiveStackTraceReporter(maxStackTraceLength: 10)
-      let longData = String(repeating: "a", count: 1000).data(using: .utf8)!
-      let result = shortCollector.formatStackTrace(rawStackTrace: longData)
-
-      XCTAssertTrue(result.stacktrace.count <= 1000)
-    }
-
-    func testGetFirstFrameOfMainWithLibraryAndOffset() {
-      let stacktrace = """
-      Thread 0:
-      0   libsystem_kernel.dylib              0x00000001dccb1658 0x1dccab000 + 26200
-      1   Foundation                          0x000000018a9b4c2c 0x18a707000 + 2808876
-      """
-
-      let result = collector.getFirstFrameOfMain(stacktrace: stacktrace)
-      XCTAssertEqual(result, "libsystem_kernel.dylib + 26200")
-    }
-
-    func testGetFirstFrameOfMainWithAppHang() {
-      let stacktrace = """
-      Thread 0:
-      0   libsystem_kernel.dylib              0x00000001dccb1658 0x1dccab000 + 26200
-      1   Foundation                          0x000000018a9b4c2c 0x18a707000 + 2808876
-      2   AwsHackerNewsDemo                   0x0000000100714984 0x1006dc000 + 231812
-      """
-
-      let result = collector.getFirstFrameOfMain(stacktrace: stacktrace)
-      XCTAssertEqual(result, "libsystem_kernel.dylib + 26200")
-    }
-
-    func testGetFirstFrameOfMainWithDifferentLibrary() {
-      let stacktrace = """
-      Thread 0:
-      0   CoreFoundation                      0x000000018baf9d90 0x18ba8d000 + 445840
-      1   libdispatch.dylib                   0x0000000193a27c6c 0x193a17000 + 68716
-      """
-
-      let result = collector.getFirstFrameOfMain(stacktrace: stacktrace)
-      XCTAssertEqual(result, "CoreFoundation + 445840")
-    }
-
-    func testGetFirstFrameOfMainWithInsufficientComponents() {
-      let stacktrace = """
-      Thread 0:
-      0   MyApp
-      """
-
-      let result = collector.getFirstFrameOfMain(stacktrace: stacktrace)
-      XCTAssertEqual(result, "unknown location")
-    }
-
-    func testGetFirstFrameOfMainWithNoMainThread() {
-      let stacktrace = "Some other thread info"
-      let result = collector.getFirstFrameOfMain(stacktrace: stacktrace)
-      XCTAssertNil(result)
-    }
-
-    func testGetFirstFrameOfMainWithEmptyStacktrace() {
-      let stacktrace = ""
-      let result = collector.getFirstFrameOfMain(stacktrace: stacktrace)
-      XCTAssertNil(result)
-    }
-
-    func testGetFirstFrameOfMainWithMalformedStacktrace() {
-      let stacktrace = "Thread 0:\n0"
-      let result = collector.getFirstFrameOfMain(stacktrace: stacktrace)
-      XCTAssertEqual(result, "unknown location")
-    }
-
-    func testFormatStackTraceWithNilReportString() {
-      let malformedData = Data([0x00, 0x01, 0x02, 0x03])
-      let result = collector.formatStackTrace(rawStackTrace: malformedData)
-
-      XCTAssertEqual(result.message, "Hang detected at unknown location")
-      XCTAssertTrue(result.stacktrace.contains("Failed to"))
-    }
+  override func setUp() {
+    super.setUp()
+    collector = KSCrashLiveStackTraceReporter(maxStackTraceLength: 1000)
   }
-#endif
+
+  override func tearDown() {
+    collector = nil
+    super.tearDown()
+  }
+
+  func testInitialization() {
+    XCTAssertEqual(collector.maxStackTraceLength, 1000)
+  }
+
+  func testDefaultInitialization() {
+    let defaultCollector = KSCrashLiveStackTraceReporter()
+    XCTAssertEqual(defaultCollector.maxStackTraceLength, 10000)
+  }
+
+  func testGenerateLiveStackTrace() {
+    XCTAssertNoThrow(collector.generateLiveStackTrace())
+  }
+
+  func testFormatStackTraceWithInvalidData() {
+    let invalidData = "invalid data".data(using: .utf8)!
+    let result = collector.formatStackTrace(rawStackTrace: invalidData)
+
+    XCTAssertEqual(result.message, "Hang detected at unknown location")
+    XCTAssertEqual(result.stacktrace, "Failed to parse stack trace")
+  }
+
+  func testFormatStackTraceWithEmptyData() {
+    let emptyData = Data()
+    let result = collector.formatStackTrace(rawStackTrace: emptyData)
+
+    XCTAssertEqual(result.message, "Hang detected at unknown location")
+    XCTAssertEqual(result.stacktrace, "Failed to parse stack trace")
+  }
+
+  func testFormatStackTraceWithValidAddresses() {
+    let addresses: [UInt] = [0x1000, 0x2000, 0x3000]
+    let data = try! JSONEncoder().encode(addresses)
+    let result = collector.formatStackTrace(rawStackTrace: data)
+
+    XCTAssertTrue(result.stacktrace.hasPrefix("Thread 0:\n"))
+    XCTAssertTrue(result.message.hasPrefix("Hang detected at"))
+  }
+
+  func testFormatStackTraceWithEmptyAddresses() {
+    let addresses: [UInt] = []
+    let data = try! JSONEncoder().encode(addresses)
+    let result = collector.formatStackTrace(rawStackTrace: data)
+
+    XCTAssertEqual(result.message, "Hang detected at unknown location")
+    XCTAssertEqual(result.stacktrace, "Failed to parse stack trace")
+  }
+
+  func testMaxStackTraceLengthTruncation() {
+    let shortCollector = KSCrashLiveStackTraceReporter(maxStackTraceLength: 20)
+    let addresses: [UInt] = Array(repeating: 0x1000, count: 50)
+    let data = try! JSONEncoder().encode(addresses)
+    let result = shortCollector.formatStackTrace(rawStackTrace: data)
+
+    XCTAssertTrue(result.stacktrace.count <= 20)
+  }
+}
 
 // MARK: - StackTrace Struct Tests
 
@@ -183,17 +125,15 @@ final class StackTraceTests: XCTestCase {
 // MARK: - Protocol Conformance Tests
 
 final class LiveStackTraceReporterProtocolTests: XCTestCase {
-  func testPLLiveStackTraceReporterConformsToProtocol() {
-    #if !os(watchOS)
-      let collector: LiveStackTraceReporter = PLLiveStackTraceReporter(maxStackTraceLength: 1000)
-      XCTAssertEqual(collector.maxStackTraceLength, 1000)
-      XCTAssertNoThrow(collector.generateLiveStackTrace())
+  func testKSCrashLiveStackTraceReporterConformsToProtocol() {
+    let collector: LiveStackTraceReporter = KSCrashLiveStackTraceReporter(maxStackTraceLength: 1000)
+    XCTAssertEqual(collector.maxStackTraceLength, 1000)
+    XCTAssertNoThrow(collector.generateLiveStackTrace())
 
-      let data = Data()
-      let result = collector.formatStackTrace(rawStackTrace: data)
-      XCTAssertNotNil(result.message)
-      XCTAssertNotNil(result.stacktrace)
-    #endif
+    let data = Data()
+    let result = collector.formatStackTrace(rawStackTrace: data)
+    XCTAssertNotNil(result.message)
+    XCTAssertNotNil(result.stacktrace)
   }
 
   func testNoopStackTraceCollectorConformsToProtocol() {


### PR DESCRIPTION
## Summary

Closes #85

Remove the deprecated PLCrashReporter dependency and use KSCrash's captureBacktrace/symbolicate API for collecting live stack traces during hang detection. KSCrash is already a dependency so this removes an unnecessary third-party library while maintaining the same functionality.

Key changes:
- Replace PLLiveStackTraceReporter with KSCrashLiveStackTraceReporter
- Remove platform conditional (#if !os(watchOS)) since KSCrash works on all Apple platforms including watchOS
- Remove plcrashreporter from Package.swift dependencies
- Add Recording product dependency for KSCrashRecordingCore access
- Update tests to cover the new implementation


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

