### PR TITLE
feat(contract): Make the contract test endpoint configurable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,40 @@ make contract-test-run-visionos
 ./scripts/run-contract-tests.sh --destination ios
 ```
 
+### Contract testing against a custom endpoint
+
+By default the contract tests are hermetic: the demo app exports to the local AwsOtelUI server on
+`http://localhost:3000`, and the assertions in `Tests/ContractTests` parse the payloads it dumps to
+`Examples/AwsOtelUI/out`.
+
+The target is configurable, so the same suite can drive telemetry into a real endpoint:
+
+```bash
+./scripts/run-contract-tests.sh --destination ios \
+  --endpoint https://dataplane.rum.us-east-1.amazonaws.com/v1/rum \
+  --region us-east-1 \
+  --app-monitor-id 00000000-0000-0000-0000-000000000000
+```
+
+Each flag also reads an environment variable — `AWS_OTEL_CONTRACT_EXPORT_ENDPOINT`,
+`AWS_OTEL_CONTRACT_REGION`, `AWS_OTEL_CONTRACT_APP_MONITOR_ID` — so CI can supply them as secrets.
+Notes:
+
+- An endpoint with no path (`http://localhost:3000`) gets the standard OTLP per-signal paths
+  appended (`/v1/logs`, `/v1/traces`); an endpoint that already has a path is used verbatim for both
+  signals, which is what CloudWatch RUM's single `/v1/rum` path needs.
+- Supplying any endpoint other than `http://localhost:3000` selects real-endpoint mode: the local
+  `:3000` server is not started and the output assertions are skipped, because nothing is written
+  locally. The MockEndpoint server on `:8181` still runs — the app calls it to generate network
+  telemetry.
+- Leaving the endpoint unset in the app's own environment builds no `AwsExportOverride` at all, so
+  the SDK targets `https://dataplane.rum.<region>.amazonaws.com/v1/rum`. An empty value is treated
+  the same as unset.
+- Values never appear in the logs (the app monitor id and the endpoint are secrets in CI), and they
+  travel to the simulator through the launch *environment*, not launch arguments. The resolution
+  rules live in `Examples/SimpleAwsDemo/SimpleAwsDemo/ContractTest/ContractTestConfig.swift` and are
+  unit tested by `Tests/ContractTestConfigTests`.
+
 **Via Xcode:**
 
 1. Open project in Xcode

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,10 +109,12 @@ Notes:
 - Leaving the endpoint unset in the app's own environment builds no `AwsExportOverride` at all, so
   the SDK targets `https://dataplane.rum.<region>.amazonaws.com/v1/rum`. An empty value is treated
   the same as unset.
-- Values never appear in the logs (the app monitor id and the endpoint are secrets in CI), and they
-  travel to the simulator through the launch *environment*, not launch arguments. The resolution
-  rules live in `Examples/SimpleAwsDemo/SimpleAwsDemo/ContractTest/ContractTestConfig.swift` and are
-  unit tested by `Tests/ContractTestConfigTests`.
+- The harness never echoes the values (the app monitor id and the endpoint are secrets in CI): the
+  script, the Makefile and the UI test log key names only. They travel to the simulator through the
+  launch *environment*, not launch arguments, because the app prints its own launch arguments at
+  startup. The resolution rules live in
+  `Examples/SimpleAwsDemo/SimpleAwsDemo/ContractTest/ContractTestConfig.swift` and are unit tested
+  by `Tests/ContractTestConfigTests`.
 
 **Via Xcode:**
 

--- a/Examples/SimpleAwsDemo/Makefile
+++ b/Examples/SimpleAwsDemo/Makefile
@@ -18,6 +18,15 @@ PERFORMANCE_TEST_PLAN="PerformanceTests"
 # These are `export`ed rather than written into the recipe so make never echoes their values:
 # the app monitor id is a secret in CI. Unset variables export as empty, which the app treats
 # exactly like unset (no `AwsExportOverride` is built).
+#
+# The endpoint is defaulted to the local AwsOtelUI server so that these targets stay hermetic even
+# when invoked directly rather than through `scripts/run-contract-tests.sh`. Without it an unset
+# endpoint would make the app export to the real regional data plane with a placeholder app monitor
+# id. Region and app monitor id are left empty on purpose: the app defaults those itself.
+ifeq ($(strip $(AWS_OTEL_CONTRACT_EXPORT_ENDPOINT)),)
+AWS_OTEL_CONTRACT_EXPORT_ENDPOINT = http://localhost:3000
+endif
+
 TEST_RUNNER_AWS_OTEL_CONTRACT_EXPORT_ENDPOINT = $(AWS_OTEL_CONTRACT_EXPORT_ENDPOINT)
 TEST_RUNNER_AWS_OTEL_CONTRACT_REGION = $(AWS_OTEL_CONTRACT_REGION)
 TEST_RUNNER_AWS_OTEL_CONTRACT_APP_MONITOR_ID = $(AWS_OTEL_CONTRACT_APP_MONITOR_ID)

--- a/Examples/SimpleAwsDemo/Makefile
+++ b/Examples/SimpleAwsDemo/Makefile
@@ -5,7 +5,29 @@ CONTRACT_TEST_PLAN="UITests"
 
 PERFORMANCE_TEST_PLAN="PerformanceTests"
 
-### START CONTRACT TEST - DATA GENERATION OPTIONS 
+### START CONTRACT TEST - HARNESS CONFIGURATION
+#
+# Endpoint / region / app monitor id for the app under test. `scripts/run-contract-tests.sh`
+# supplies them (defaulting the endpoint to the local AwsOtelUI server); they can also be set
+# directly in the environment.
+#
+# `xcodebuild` copies `TEST_RUNNER_`-prefixed variables into the UI test runner's environment
+# with the prefix stripped, and `UITests/EmptyUITests.swift` re-injects them into the app's
+# launch environment — the runner and the app are different processes.
+#
+# These are `export`ed rather than written into the recipe so make never echoes their values:
+# the app monitor id is a secret in CI. Unset variables export as empty, which the app treats
+# exactly like unset (no `AwsExportOverride` is built).
+TEST_RUNNER_AWS_OTEL_CONTRACT_EXPORT_ENDPOINT = $(AWS_OTEL_CONTRACT_EXPORT_ENDPOINT)
+TEST_RUNNER_AWS_OTEL_CONTRACT_REGION = $(AWS_OTEL_CONTRACT_REGION)
+TEST_RUNNER_AWS_OTEL_CONTRACT_APP_MONITOR_ID = $(AWS_OTEL_CONTRACT_APP_MONITOR_ID)
+export TEST_RUNNER_AWS_OTEL_CONTRACT_EXPORT_ENDPOINT
+export TEST_RUNNER_AWS_OTEL_CONTRACT_REGION
+export TEST_RUNNER_AWS_OTEL_CONTRACT_APP_MONITOR_ID
+
+### END CONTRACT TEST - HARNESS CONFIGURATION
+
+### START CONTRACT TEST - DATA GENERATION OPTIONS
 
 XCODEBUILD_OPTIONS_IOS_CONTRACT=\
 	-project $(CONTRACT_TEST_WORKSPACE) \

--- a/Examples/SimpleAwsDemo/SimpleAwsDemo/ContractTest/ContractTestConfig.swift
+++ b/Examples/SimpleAwsDemo/SimpleAwsDemo/ContractTest/ContractTestConfig.swift
@@ -39,8 +39,9 @@ public enum ContractTestEndpointResolution: Equatable {
 /// secret.
 ///
 /// With nothing set the resolved values are the real regional endpoint plus the placeholder
-/// region/app monitor id the demo app has always shipped; the hermetic localhost endpoint is
-/// supplied by `scripts/run-contract-tests.sh`, which defaults it when no endpoint is given.
+/// region/app monitor id the demo app has always shipped. The hermetic localhost endpoint comes
+/// from the harness, which defaults it at both entry points: `scripts/run-contract-tests.sh` and
+/// `Examples/SimpleAwsDemo/Makefile` (so the make targets stay hermetic when invoked directly).
 public struct ContractTestConfig: Equatable {
   /// Shared prefix for every variable the harness forwards. `UITests/EmptyUITests.swift`
   /// forwards by prefix, so a new variable needs no change there.
@@ -96,19 +97,34 @@ public struct ContractTestConfig: Equatable {
           let scheme = components.scheme?.lowercased(),
           allowedSchemes.contains(scheme),
           let host = components.host,
-          !host.isEmpty else {
+          !host.isEmpty,
+          components.query == nil,
+          components.fragment == nil,
+          components.user == nil,
+          components.password == nil else {
       return .invalid(
-        reason: "\(endpointKey) must be an http(s) URL with a host, e.g. http://localhost:3000 "
-          + "or https://dataplane.rum.<region>.amazonaws.com/v1/rum"
+        reason: "\(endpointKey) must be an http(s) URL with a host and no query, fragment or "
+          + "embedded credentials, e.g. http://localhost:3000 or "
+          + "https://dataplane.rum.<region>.amazonaws.com/v1/rum"
       )
     }
 
     let path = components.path
-    if path.isEmpty || path == "/" {
-      let origin = endpoint.hasSuffix("/") ? String(endpoint.dropLast()) : endpoint
-      return .override(logs: origin + logsPath, traces: origin + tracesPath)
+    guard path.isEmpty || path == "/" else {
+      // Already a per-signal (or single-path) URL: use it as given.
+      return .override(logs: endpoint, traces: endpoint)
     }
 
-    return .override(logs: endpoint, traces: endpoint)
+    // Rebuild the origin from the parsed components rather than slicing the input, so a
+    // trailing slash, an uppercase scheme or any other cosmetic difference cannot produce a
+    // malformed URL once the per-signal path is appended.
+    var originComponents = URLComponents()
+    originComponents.scheme = scheme
+    originComponents.host = host
+    originComponents.port = components.port
+    guard let origin = originComponents.string else {
+      return .invalid(reason: "\(endpointKey) could not be normalized into an origin URL")
+    }
+    return .override(logs: origin + logsPath, traces: origin + tracesPath)
   }
 }

--- a/Examples/SimpleAwsDemo/SimpleAwsDemo/ContractTest/ContractTestConfig.swift
+++ b/Examples/SimpleAwsDemo/SimpleAwsDemo/ContractTest/ContractTestConfig.swift
@@ -14,3 +14,101 @@
  */
 
 import Foundation
+
+/// How the export endpoint was resolved from the environment.
+public enum ContractTestEndpointResolution: Equatable {
+  /// No endpoint was supplied. No `AwsExportOverride` must be constructed, so the SDK
+  /// targets the real regional endpoint (`https://dataplane.rum.<region>.amazonaws.com/v1/rum`).
+  case unset
+
+  /// An endpoint was supplied and is usable.
+  case override(logs: String, traces: String)
+
+  /// An endpoint was supplied but cannot be used. Callers must fail loudly rather than
+  /// fall back to `unset`: silently retargeting a test run at the real data plane is worse
+  /// than not exporting at all.
+  case invalid(reason: String)
+}
+
+/// Contract test harness configuration, resolved from the process environment.
+///
+/// The harness (`scripts/run-contract-tests.sh` → `Examples/SimpleAwsDemo/Makefile` →
+/// `xcodebuild` → `UITests/EmptyUITests.swift`) hands these values to the demo app through
+/// the simulator **launch environment**. They are deliberately not launch arguments: the app
+/// prints `ProcessInfo.processInfo.arguments` at startup, and the app monitor id is a CI
+/// secret.
+///
+/// With nothing set the resolved values are the real regional endpoint plus the placeholder
+/// region/app monitor id the demo app has always shipped; the hermetic localhost endpoint is
+/// supplied by `scripts/run-contract-tests.sh`, which defaults it when no endpoint is given.
+public struct ContractTestConfig: Equatable {
+  /// Shared prefix for every variable the harness forwards. `UITests/EmptyUITests.swift`
+  /// forwards by prefix, so a new variable needs no change there.
+  public static let environmentKeyPrefix = "AWS_OTEL_CONTRACT_"
+
+  /// Export endpoint. Either an origin (`http://localhost:3000`), in which case the standard
+  /// OTLP per-signal paths are appended, or a full URL (`.../v1/rum`), used verbatim for both
+  /// signals — CloudWatch RUM accepts logs and traces on the same path.
+  public static let endpointKey = environmentKeyPrefix + "EXPORT_ENDPOINT"
+
+  /// AWS region passed to `AwsConfig`.
+  public static let regionKey = environmentKeyPrefix + "REGION"
+
+  /// RUM app monitor **id** (a UUID, not the monitor name) passed to `AwsConfig`. A secret in CI.
+  public static let appMonitorIdKey = environmentKeyPrefix + "APP_MONITOR_ID"
+
+  /// Region used when none is supplied. Pinned by `Tests/ContractTests/ResourceAttributesTests.swift`.
+  public static let defaultRegion = "us-east-1"
+
+  /// App monitor id used when none is supplied. Pinned by `Tests/ContractTests/ResourceAttributesTests.swift`.
+  public static let defaultAppMonitorId = "test-app-monitor-id"
+
+  private static let logsPath = "/v1/logs"
+  private static let tracesPath = "/v1/traces"
+  private static let allowedSchemes = ["http", "https"]
+
+  public let region: String
+  public let appMonitorId: String
+  public let endpoints: ContractTestEndpointResolution
+
+  /// Resolves the harness configuration from an environment dictionary.
+  ///
+  /// Every value is trimmed — CI secrets routinely arrive with a trailing newline — and an
+  /// empty value is treated exactly like an absent one.
+  public static func resolve(environment: [String: String] = ProcessInfo.processInfo.environment) -> ContractTestConfig {
+    ContractTestConfig(
+      region: value(for: regionKey, in: environment) ?? defaultRegion,
+      appMonitorId: value(for: appMonitorIdKey, in: environment) ?? defaultAppMonitorId,
+      endpoints: resolveEndpoints(value(for: endpointKey, in: environment))
+    )
+  }
+
+  private static func value(for key: String, in environment: [String: String]) -> String? {
+    guard let raw = environment[key] else { return nil }
+    let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed.isEmpty ? nil : trimmed
+  }
+
+  private static func resolveEndpoints(_ endpoint: String?) -> ContractTestEndpointResolution {
+    guard let endpoint else { return .unset }
+
+    guard let components = URLComponents(string: endpoint),
+          let scheme = components.scheme?.lowercased(),
+          allowedSchemes.contains(scheme),
+          let host = components.host,
+          !host.isEmpty else {
+      return .invalid(
+        reason: "\(endpointKey) must be an http(s) URL with a host, e.g. http://localhost:3000 "
+          + "or https://dataplane.rum.<region>.amazonaws.com/v1/rum"
+      )
+    }
+
+    let path = components.path
+    if path.isEmpty || path == "/" {
+      let origin = endpoint.hasSuffix("/") ? String(endpoint.dropLast()) : endpoint
+      return .override(logs: origin + logsPath, traces: origin + tracesPath)
+    }
+
+    return .override(logs: endpoint, traces: endpoint)
+  }
+}

--- a/Examples/SimpleAwsDemo/SimpleAwsDemo/ContractTest/ContractTestConfig.swift
+++ b/Examples/SimpleAwsDemo/SimpleAwsDemo/ContractTest/ContractTestConfig.swift
@@ -1,0 +1,16 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import Foundation

--- a/Examples/SimpleAwsDemo/SimpleAwsDemo/SimpleAwsDemoApp.swift
+++ b/Examples/SimpleAwsDemo/SimpleAwsDemo/SimpleAwsDemoApp.swift
@@ -34,10 +34,27 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
   /** Unauthenticated Example */
   private func setupOpenTelemetry() {
-    let awsConfig = AwsConfig(region: "us-east-1", rumAppMonitorId: "test-app-monitor-id")
-    let exportOverride = AwsExportOverride(
-      logs: "http://localhost:3000/v1/logs",
-      traces: "http://localhost:3000/v1/traces"
+    // Region, app monitor id and export endpoint come from the launch environment so the
+    // contract test harness can point this app at either the local AwsOtelUI server or a real
+    // RUM data plane. See ContractTest/ContractTestConfig.swift for the defaults.
+    let contractTestConfig = ContractTestConfig.resolve()
+
+    let exportOverride: AwsExportOverride?
+    switch contractTestConfig.endpoints {
+    case .unset:
+      // No override: the SDK targets https://dataplane.rum.<region>.amazonaws.com/v1/rum.
+      exportOverride = nil
+    case let .override(logs, traces):
+      exportOverride = AwsExportOverride(logs: logs, traces: traces)
+    case let .invalid(reason):
+      // Refuse to initialize rather than quietly exporting somewhere unintended.
+      print("Not initializing OpenTelemetry: \(reason)")
+      return
+    }
+
+    let awsConfig = AwsConfig(
+      region: contractTestConfig.region,
+      rumAppMonitorId: contractTestConfig.appMonitorId
     )
     let config = AwsOpenTelemetryConfig(
       aws: awsConfig,

--- a/Examples/SimpleAwsDemo/UITests/EmptyUITests.swift
+++ b/Examples/SimpleAwsDemo/UITests/EmptyUITests.swift
@@ -3,11 +3,34 @@ import XCTest
 class EmptyUITests: XCTestCase {
   var app: XCUIApplication!
 
+  /// Prefix shared by every contract test harness variable. Kept as a literal because a UI test
+  /// bundle cannot import the app under test; `ContractTestConfigTests` asserts that every key
+  /// `ContractTestConfig` reads carries this prefix, so the two cannot drift silently.
+  private static let harnessEnvironmentPrefix = "AWS_OTEL_CONTRACT_"
+
   override func setUpWithError() throws {
     continueAfterFailure = false
     app = XCUIApplication()
     app.launchArguments.append("--contractTestMode")
+    // Forward harness configuration into the simulator. `xcodebuild` hands these to the test
+    // runner via `TEST_RUNNER_`-prefixed variables (the prefix is stripped before we see them);
+    // the runner is a different process from the app, so they have to be re-injected here.
+    //
+    // Launch *environment*, never launch arguments: the app prints its arguments at startup and
+    // the app monitor id is a CI secret.
+    app.launchEnvironment.merge(Self.harnessEnvironment()) { _, forwarded in forwarded }
+    // Key names only. Never log the values — one of them is a secret.
+    print("Forwarding harness environment keys: \(Self.harnessEnvironment().keys.sorted())")
     app.launch()
+  }
+
+  /// The harness variables visible to this runner process, forwarded by prefix so adding a new
+  /// variable needs no change here.
+  private static func harnessEnvironment() -> [String: String] {
+    ProcessInfo.processInfo.environment.filter { key, value in
+      key.hasPrefix(harnessEnvironmentPrefix)
+        && !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
   }
 
   // Note: the 15 second stall is just to give the github host enough time to do all the mock interactions, and send all the telemetries

--- a/Examples/SimpleAwsDemo/UITests/EmptyUITests.swift
+++ b/Examples/SimpleAwsDemo/UITests/EmptyUITests.swift
@@ -18,9 +18,11 @@ class EmptyUITests: XCTestCase {
     //
     // Launch *environment*, never launch arguments: the app prints its arguments at startup and
     // the app monitor id is a CI secret.
-    app.launchEnvironment.merge(Self.harnessEnvironment()) { _, forwarded in forwarded }
-    // Key names only. Never log the values — one of them is a secret.
-    print("Forwarding harness environment keys: \(Self.harnessEnvironment().keys.sorted())")
+    let harnessEnvironment = Self.harnessEnvironment()
+    app.launchEnvironment.merge(harnessEnvironment) { _, forwarded in forwarded }
+    // Key names only, and only the ones actually forwarded above. Never log the values — one of
+    // them is a secret.
+    print("Forwarding harness environment keys: \(harnessEnvironment.keys.sorted())")
     app.launch()
   }
 

--- a/Package.swift
+++ b/Package.swift
@@ -87,6 +87,19 @@ let package = Package(
       dependencies: ["AwsOpenTelemetryCore"],
       path: "Tests/ContractTests",
       exclude: ["MockEndpoint/"]
+    ),
+    // Contract test harness configuration, resolved from the environment. Xcode compiles
+    // these sources into the SimpleAwsDemo app directly (its target is a file-system
+    // synchronized group). The target is declared here only so the resolution rules can be
+    // unit tested without a simulator; it is deliberately not exposed as a product.
+    .target(
+      name: "ContractTestConfig",
+      path: "Examples/SimpleAwsDemo/SimpleAwsDemo/ContractTest"
+    ),
+    .testTarget(
+      name: "ContractTestConfigTests",
+      dependencies: ["ContractTestConfig"],
+      path: "Tests/ContractTestConfigTests"
     )
   ]
 ).addPlatformSpecific()

--- a/Tests/ContractTestConfigTests/ContractTestConfigTests.swift
+++ b/Tests/ContractTestConfigTests/ContractTestConfigTests.swift
@@ -18,8 +18,13 @@ import XCTest
 
 /// Unit tests for the contract test harness' environment resolution.
 ///
-/// These are pure (no simulator, no network, no files) so they run anywhere
-/// `swift test` runs, including as part of `swift test --filter ContractTests`.
+/// These are pure (no simulator, no network, no files), so they run wherever the package's
+/// ordinary unit tests run: `swift test --skip ContractTests` (hence `make check-coverage`) and
+/// the `make test-*` platform targets, which skip only the `ContractTests` target by name.
+///
+/// They are deliberately *not* reached by the contract test step's
+/// `swift test --filter ContractTests` — that regex does not match `ContractTestConfigTests` —
+/// because they assert resolution rules, not exported payloads.
 class ContractTestConfigTests: XCTestCase {
   // MARK: - No endpoint supplied
 
@@ -71,7 +76,24 @@ class ContractTestConfigTests: XCTestCase {
   /// Given an endpoint that cannot be used, when the config is resolved, then the failure is
   /// reported explicitly instead of silently falling back to the real regional endpoint.
   func testUnusableEndpointIsReportedAsInvalid() {
-    for value in ["not-a-url", "localhost:3000", "ftp://localhost:3000", "http://", "http:///v1/rum"] {
+    let unusable = [
+      "not-a-url",
+      "localhost:3000",
+      "ftp://localhost:3000",
+      "http://",
+      "http:///v1/rum",
+      // A query or fragment cannot be reconciled with appending a per-signal path, so it is
+      // rejected rather than silently mangled into `http://host?x=1/v1/logs`.
+      "http://localhost:3000?x=1",
+      "http://localhost:3000#frag",
+      "https://dataplane.rum.us-east-1.amazonaws.com/v1/rum?x=1",
+      // Embedded credentials would be dropped when the origin is reassembled, silently
+      // retargeting the exporter. Rejected instead.
+      "http://user:pass@localhost:3000",
+      "http://user@localhost:3000/v1/rum"
+    ]
+
+    for value in unusable {
       let config = ContractTestConfig.resolve(environment: [ContractTestConfig.endpointKey: value])
 
       guard case let .invalid(reason) = config.endpoints else {
@@ -83,6 +105,35 @@ class ContractTestConfigTests: XCTestCase {
         "reason should name the offending variable so a failing run is diagnosable: \(reason)"
       )
     }
+  }
+
+  /// The origin is rebuilt from the parsed URL rather than sliced out of the raw string, so
+  /// cosmetic differences in the input cannot produce a malformed export URL. (The
+  /// trailing-slash form is covered by `testOriginOnlyEndpointGetsPerSignalOtlpPaths`.)
+  func testOriginIsNormalizedBeforeThePerSignalPathIsAppended() {
+    let config = ContractTestConfig.resolve(environment: [
+      ContractTestConfig.endpointKey: "HTTP://localhost:3000"
+    ])
+
+    XCTAssertEqual(
+      config.endpoints,
+      .override(logs: "http://localhost:3000/v1/logs", traces: "http://localhost:3000/v1/traces")
+    )
+  }
+
+  /// A host with no port must not gain a stray colon when the origin is reassembled.
+  func testOriginWithoutAPortKeepsItsShape() {
+    let config = ContractTestConfig.resolve(environment: [
+      ContractTestConfig.endpointKey: "https://dataplane.rum.us-east-1.amazonaws.com"
+    ])
+
+    XCTAssertEqual(
+      config.endpoints,
+      .override(
+        logs: "https://dataplane.rum.us-east-1.amazonaws.com/v1/logs",
+        traces: "https://dataplane.rum.us-east-1.amazonaws.com/v1/traces"
+      )
+    )
   }
 
   // MARK: - Region and app monitor id

--- a/Tests/ContractTestConfigTests/ContractTestConfigTests.swift
+++ b/Tests/ContractTestConfigTests/ContractTestConfigTests.swift
@@ -1,0 +1,147 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import XCTest
+@testable import ContractTestConfig
+
+/// Unit tests for the contract test harness' environment resolution.
+///
+/// These are pure (no simulator, no network, no files) so they run anywhere
+/// `swift test` runs, including as part of `swift test --filter ContractTests`.
+class ContractTestConfigTests: XCTestCase {
+  // MARK: - No endpoint supplied
+
+  /// Given no endpoint in the environment, when the config is resolved, then no export
+  /// override is described at all, so the SDK falls through to the real regional endpoint.
+  func testUnsetEndpointResolvesToNoOverride() {
+    let config = ContractTestConfig.resolve(environment: [:])
+
+    XCTAssertEqual(config.endpoints, .unset)
+  }
+
+  /// Given an endpoint that is set but empty (how an unset CI secret arrives once it has
+  /// been threaded through `make`), when the config is resolved, then it is treated as
+  /// unset rather than becoming a literal empty override.
+  func testEmptyEndpointResolvesToNoOverride() {
+    for value in ["", " ", "\n", "  \n\t "] {
+      let config = ContractTestConfig.resolve(environment: [ContractTestConfig.endpointKey: value])
+
+      XCTAssertEqual(config.endpoints, .unset, "expected \(value.debugDescription) to be treated as unset")
+    }
+  }
+
+  // MARK: - Endpoint supplied
+
+  /// Given an origin-only endpoint, when the config is resolved, then the standard OTLP
+  /// per-signal paths are appended — this is what keeps the hermetic localhost run working.
+  func testOriginOnlyEndpointGetsPerSignalOtlpPaths() {
+    for value in ["http://localhost:3000", "http://localhost:3000/", "  http://localhost:3000  "] {
+      let config = ContractTestConfig.resolve(environment: [ContractTestConfig.endpointKey: value])
+
+      XCTAssertEqual(
+        config.endpoints,
+        .override(logs: "http://localhost:3000/v1/logs", traces: "http://localhost:3000/v1/traces"),
+        "unexpected resolution for \(value.debugDescription)"
+      )
+    }
+  }
+
+  /// Given an endpoint that already carries a path, when the config is resolved, then it is
+  /// used verbatim for both signals. CloudWatch RUM accepts both signals on `/v1/rum`.
+  func testEndpointWithPathIsUsedVerbatimForBothSignals() {
+    let endpoint = "https://dataplane.rum.us-east-1.amazonaws.com/v1/rum"
+
+    let config = ContractTestConfig.resolve(environment: [ContractTestConfig.endpointKey: endpoint])
+
+    XCTAssertEqual(config.endpoints, .override(logs: endpoint, traces: endpoint))
+  }
+
+  /// Given an endpoint that cannot be used, when the config is resolved, then the failure is
+  /// reported explicitly instead of silently falling back to the real regional endpoint.
+  func testUnusableEndpointIsReportedAsInvalid() {
+    for value in ["not-a-url", "localhost:3000", "ftp://localhost:3000", "http://", "http:///v1/rum"] {
+      let config = ContractTestConfig.resolve(environment: [ContractTestConfig.endpointKey: value])
+
+      guard case let .invalid(reason) = config.endpoints else {
+        XCTFail("expected \(value.debugDescription) to be reported invalid, got \(config.endpoints)")
+        continue
+      }
+      XCTAssertTrue(
+        reason.contains(ContractTestConfig.endpointKey),
+        "reason should name the offending variable so a failing run is diagnosable: \(reason)"
+      )
+    }
+  }
+
+  // MARK: - Region and app monitor id
+
+  func testRegionAndAppMonitorIdComeFromTheEnvironment() {
+    let config = ContractTestConfig.resolve(environment: [
+      ContractTestConfig.regionKey: "us-west-2",
+      ContractTestConfig.appMonitorIdKey: "2a572e14-0000-0000-0000-000000000000"
+    ])
+
+    XCTAssertEqual(config.region, "us-west-2")
+    XCTAssertEqual(config.appMonitorId, "2a572e14-0000-0000-0000-000000000000")
+  }
+
+  /// CI secrets routinely arrive with a trailing newline; that must not reach the SDK.
+  func testRegionAndAppMonitorIdAreTrimmed() {
+    let config = ContractTestConfig.resolve(environment: [
+      ContractTestConfig.regionKey: " us-west-2\n",
+      ContractTestConfig.appMonitorIdKey: "\tan-app-monitor-id \n"
+    ])
+
+    XCTAssertEqual(config.region, "us-west-2")
+    XCTAssertEqual(config.appMonitorId, "an-app-monitor-id")
+  }
+
+  func testEmptyRegionAndAppMonitorIdFallBackToHermeticDefaults() {
+    let config = ContractTestConfig.resolve(environment: [
+      ContractTestConfig.regionKey: "",
+      ContractTestConfig.appMonitorIdKey: "  \n"
+    ])
+
+    XCTAssertEqual(config.region, ContractTestConfig.defaultRegion)
+    XCTAssertEqual(config.appMonitorId, ContractTestConfig.defaultAppMonitorId)
+  }
+
+  // MARK: - Regression guards
+
+  /// The hermetic contract test assertions pin these exact values
+  /// (`Tests/ContractTests/ResourceAttributesTests.swift`), and
+  /// `scripts/run-contract-tests.sh` supplies the localhost endpoint. Resolving that
+  /// environment must reproduce today's configuration exactly.
+  func testHermeticEnvironmentReproducesTodaysConfiguration() {
+    let config = ContractTestConfig.resolve(environment: [
+      ContractTestConfig.endpointKey: "http://localhost:3000"
+    ])
+
+    XCTAssertEqual(config.region, "us-east-1")
+    XCTAssertEqual(config.appMonitorId, "test-app-monitor-id")
+    XCTAssertEqual(
+      config.endpoints,
+      .override(logs: "http://localhost:3000/v1/logs", traces: "http://localhost:3000/v1/traces")
+    )
+  }
+
+  /// `UITests/EmptyUITests.swift` forwards harness variables into the simulator by prefix
+  /// rather than by name, so every key this type reads must carry that prefix.
+  func testEveryEnvironmentKeySharesTheForwardingPrefix() {
+    for key in [ContractTestConfig.endpointKey, ContractTestConfig.regionKey, ContractTestConfig.appMonitorIdKey] {
+      XCTAssertTrue(key.hasPrefix(ContractTestConfig.environmentKeyPrefix), "\(key) is not forwardable")
+    }
+  }
+}

--- a/scripts/run-contract-tests.sh
+++ b/scripts/run-contract-tests.sh
@@ -78,6 +78,19 @@ else
   HERMETIC=false
 fi
 
+# Reject an endpoint the app would refuse, here rather than 10 minutes into an xcodebuild run.
+# In real-endpoint mode there are no output assertions, so an unusable endpoint would otherwise
+# produce a green run that exported nothing. Mirrors ContractTestConfig.resolveEndpoints — http(s),
+# a host, and no query, fragment or embedded credentials — but is deliberately a shade stricter: the
+# scheme must be lowercase, so the literal hermetic comparison above cannot be side-stepped by
+# spelling the local server as HTTP://localhost:3000 (which the app would accept while this script
+# had already decided not to start it).
+if [[ ! "$ENDPOINT" =~ ^https?://[^/?#@[:space:]]+(/[^?#[:space:]]*)?$ ]]; then
+  echo "Error: endpoint must be an http(s) URL with a host and no query, fragment or credentials"
+  echo "       (the value is not echoed: it is a secret in CI). Use --help for examples."
+  exit 1
+fi
+
 # Handed to xcodebuild by Examples/SimpleAwsDemo/Makefile, which re-exports them with the
 # TEST_RUNNER_ prefix xcodebuild needs to reach the UI test runner (and from there the app).
 export AWS_OTEL_CONTRACT_EXPORT_ENDPOINT="$ENDPOINT"

--- a/scripts/run-contract-tests.sh
+++ b/scripts/run-contract-tests.sh
@@ -9,6 +9,16 @@ set -e
 DESTINATION=""
 MOCK_ENDPOINT_PORT=8181
 
+# The local AwsOtelUI server. Exporting here is what makes the default run hermetic; the app
+# itself has no localhost fallback (with nothing set it targets the real regional endpoint).
+HERMETIC_ENDPOINT="http://localhost:3000"
+
+# Harness configuration. Flags win over the environment; anything still empty is defaulted by
+# the app (region/app monitor id) or below (endpoint).
+ENDPOINT="${AWS_OTEL_CONTRACT_EXPORT_ENDPOINT:-}"
+REGION="${AWS_OTEL_CONTRACT_REGION:-}"
+APP_MONITOR_ID="${AWS_OTEL_CONTRACT_APP_MONITOR_ID:-}"
+
 # Parse arguments
 while [[ $# -gt 0 ]]; do
   case $1 in
@@ -16,9 +26,31 @@ while [[ $# -gt 0 ]]; do
       DESTINATION="$2"
       shift 2
       ;;
+    --endpoint)
+      ENDPOINT="$2"
+      shift 2
+      ;;
+    --region)
+      REGION="$2"
+      shift 2
+      ;;
+    --app-monitor-id)
+      APP_MONITOR_ID="$2"
+      shift 2
+      ;;
     -h|--help)
-      echo "Usage: $0 --destination <platform>"
-      echo "  --destination  Platform (e.g., ios, tvos, watchos, visionos)"
+      echo "Usage: $0 --destination <platform> [--endpoint <url>] [--region <region>] [--app-monitor-id <id>]"
+      echo "  --destination     Platform (e.g., ios, tvos, watchos, visionos)"
+      echo "  --endpoint        Export endpoint. Defaults to $HERMETIC_ENDPOINT (hermetic mode:"
+      echo "                    starts the local AwsOtelUI server and verifies the dumped output)."
+      echo "                    Any other endpoint selects real-endpoint mode: no local :3000"
+      echo "                    server and no output assertions (nothing is written locally)."
+      echo "  --region          AWS region for AwsConfig. Defaults to the app's built-in default."
+      echo "  --app-monitor-id  RUM app monitor id (a UUID) for AwsConfig. Secret in CI."
+      echo ""
+      echo "Each flag also reads a matching environment variable:"
+      echo "  AWS_OTEL_CONTRACT_EXPORT_ENDPOINT, AWS_OTEL_CONTRACT_REGION,"
+      echo "  AWS_OTEL_CONTRACT_APP_MONITOR_ID"
       exit 0
       ;;
     *)
@@ -35,7 +67,30 @@ if [[ -z "$DESTINATION" ]]; then
   exit 1
 fi
 
+# Hermetic mode is the default: no endpoint supplied, or the local AwsOtelUI server supplied
+# explicitly (with or without a trailing slash).
+if [[ -z "$ENDPOINT" ]]; then
+  ENDPOINT="$HERMETIC_ENDPOINT"
+fi
+if [[ "${ENDPOINT%/}" == "$HERMETIC_ENDPOINT" ]]; then
+  HERMETIC=true
+else
+  HERMETIC=false
+fi
+
+# Handed to xcodebuild by Examples/SimpleAwsDemo/Makefile, which re-exports them with the
+# TEST_RUNNER_ prefix xcodebuild needs to reach the UI test runner (and from there the app).
+export AWS_OTEL_CONTRACT_EXPORT_ENDPOINT="$ENDPOINT"
+export AWS_OTEL_CONTRACT_REGION="$REGION"
+export AWS_OTEL_CONTRACT_APP_MONITOR_ID="$APP_MONITOR_ID"
+
 echo "Running contract tests for $DESTINATION"
+# Values are deliberately not echoed: the endpoint and app monitor id are secrets in CI.
+if [[ "$HERMETIC" == true ]]; then
+  echo "Mode: hermetic (local AwsOtelUI server, output assertions enabled)"
+else
+  echo "Mode: real endpoint (no local AwsOtelUI server, output assertions skipped)"
+fi
 
 # Get the project root directory
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -79,13 +134,17 @@ if ! bash test.sh; then
 fi
 echo "MockEndpoint server verified successfully"
 
-# Start AwsOtelUI server
-echo "Starting AwsOtelUI server..."
-cd "$PROJECT_ROOT/Examples/AwsOtelUI"
-npm i
-npm start &
-SERVER_PID=$!
-sleep 5
+# Start AwsOtelUI server (hermetic mode only — in real-endpoint mode nothing exports to :3000)
+if [[ "$HERMETIC" == true ]]; then
+  echo "Starting AwsOtelUI server..."
+  cd "$PROJECT_ROOT/Examples/AwsOtelUI"
+  npm i
+  npm start &
+  SERVER_PID=$!
+  sleep 5
+else
+  echo "Skipping AwsOtelUI server: telemetry is exported to the supplied endpoint."
+fi
 
 # Generate spans and logs
 echo "Generating spans and logs for $DESTINATION..."
@@ -98,12 +157,19 @@ case $DESTINATION in
     ;;
 esac
 
-# List generated files
-echo "Generated files:"
-ls -al "$PROJECT_ROOT/Examples/AwsOtelUI/out"
+# Verify contracts. The assertions in Tests/ContractTests parse the OTLP payloads AwsOtelUI
+# dumped to Examples/AwsOtelUI/out, so they only mean something in hermetic mode. Against a real
+# data plane nothing is written locally: the put side only has to export, and verification is the
+# job of whoever reads the telemetry back out of the destination.
+if [[ "$HERMETIC" == true ]]; then
+  # List generated files
+  echo "Generated files:"
+  ls -al "$PROJECT_ROOT/Examples/AwsOtelUI/out"
 
-# Verify contracts
-cd "$PROJECT_ROOT"
-swift test --filter ContractTests
+  cd "$PROJECT_ROOT"
+  swift test --filter ContractTests
+else
+  echo "Skipping output assertions: they parse Examples/AwsOtelUI/out, which is only written in hermetic mode."
+fi
 
 echo "Contract tests completed successfully!"


### PR DESCRIPTION
## What this does

The contract tests could only ever talk to a fake server on localhost. The region, the app
monitor id, and the export URL were hardcoded in the demo app, so there was no way to point the
suite anywhere else.

This PR reads all three from the environment instead. The same tests can now drive telemetry into
a **real CloudWatch RUM endpoint** — or keep talking to localhost, which is still the default. Set
nothing and the run is byte-for-byte what it is today.

No SDK change was needed. `AwsExportOverride` is already public and is exactly what the hermetic
tests use.

## How the tests get extended

```
                ./scripts/run-contract-tests.sh --destination ios
                          [--endpoint] [--region] [--app-monitor-id]
                                          │
                                          │   three values now ride this chain
                                          ▼
   Makefile     ────►    xcodebuild    ────►   UITest runner   ────►   SimpleAwsDemo app
 re-exports as        copies them into       re-injects them into      ContractTestConfig
 TEST_RUNNER_*        the runner (prefix     app.launchEnvironment          .resolve()
                      gets stripped)        (separate processes)               │
                                                                              │
                    ┌─────────────────────────────────────────────────────────┴───┐
                    │                                                             │
            ▼ DEFAULT — unchanged                              ▼ NEW — opt in per run
                    │                                                             │
       http://localhost:3000                        https://dataplane.rum.<region>
       AwsOtelUI fake server                                .amazonaws.com/v1/rum
                    │                                                             │
       writes payloads to                                    real RUM ingests it
       Examples/AwsOtelUI/out                                             │
                    │                                            reading it back is
       swift test --filter ContractTests                       a follow-up PR (#110)
       asserts on those files                                 — not in this one
```

Both paths run the exact same app and the exact same UI test. Only the destination moves.

## The endpoint rules

| You set | What happens |
|---|---|
| nothing, or empty | No override at all — SDK targets `https://dataplane.rum.<region>.amazonaws.com/v1/rum` |
| `https://host` (no path) | Gains the standard OTLP paths: `/v1/logs` and `/v1/traces` |
| `https://host/v1/rum` | Used as-is for both signals — RUM serves both on one path |
| a bad URL (query, fragment, credentials) | App refuses to start. It must never quietly retarget the real data plane |

The origin is rebuilt from parsed `URLComponents` rather than sliced out of the raw string —
otherwise an endpoint with embedded credentials would have its userinfo silently dropped and get
retargeted.

Anything other than `http://localhost:3000` switches the script into real-endpoint mode: no local
`:3000` server, and the output assertions are skipped, because nothing is written to disk there.
The `MockEndpoint` server on `:8181` still runs — the app calls it to generate network telemetry.

## Secrets

The app monitor id is a secret in CI, so nothing on the chain ever echoes a value. `make` uses
`export` instead of inlining, the script prints only a mode line, and the UI test prints sorted key
*names*. Values travel by launch **environment**, never launch arguments, because the app prints its
own arguments at startup. Grepping every run log for a sentinel secret returned 0 hits.

## Blast radius

`.github/workflows/ContractTests.yml` is untouched. The four `contract-test-generate-data-*` recipes
are byte-for-byte unchanged. The new SwiftPM test target lives under `Examples/`, and
`check-coverage.sh` sums only `^Sources/` rows, so it cannot move the 85% coverage gate.
`--filter ContractTests` does not match `ContractTestConfigTests`, so the contract-test step ignores
them; `BuildAndTest.yml` runs them.

## Testing

- 12/12 resolver unit tests pass.
- `make` → `xcodebuild` forwarding verified with stub `xcodebuild`/`xcbeautify` on `PATH`: unset,
  explicitly-empty, and real values all forward correctly, and the echoed recipe line is identical
  in all three cases and contains no values.
- Script mode selection verified with stubs: a malformed endpoint exits before starting any server;
  the hermetic default runs the full flow; a real endpoint skips AwsOtelUI and the output assertions
  while still exercising `MockEndpoint`.

### Why this is still a draft

The authoring host is Linux, so the hermetic **simulator** run was never executed locally — the real
package graph doesn't even resolve there (`URLSessionInstrumentation` is Darwin-only) and the unit
tests ran in a mirror package. The `xcodebuild → runner → app` hop is therefore unproved locally.

CI on this PR is the verification. In hermetic mode the localhost endpoint reaches the app *only*
through that chain, so if any link is broken `Examples/AwsOtelUI/out` stays empty and every existing
contract assertion fails. A green `ContractTests` run here is the proof.

Real-endpoint mode has deliberately never been run against AWS from this branch.
